### PR TITLE
Correct README's EPSG code

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ floating point types.
 
 Vector tiles are serialized as protobuf messages which are then zlib compressed.
 
-The assumed projection is Spherical Mercator (`epsg:3957`).
+The assumed projection is Spherical Mercator (`epsg:3785`).
 
 ## Requires
 


### PR DESCRIPTION
http://spatialreference.org/ref/epsg/3957/ 404's, http://spatialreference.org/ref/epsg/3785/ describes "Web Mercator".
