### PR TITLE
Use --dep-libs instead of listing (some) of the dependencies manually

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROTOBUF_CXXFLAGS=$(shell pkg-config protobuf --cflags)
 PROTOBUF_LDFLAGS=$(shell pkg-config protobuf --libs-only-L) -lprotobuf-lite
 MAPNIK_CXXFLAGS=$(shell mapnik-config --cflags)
-MAPNIK_LDFLAGS=$(shell mapnik-config --libs --ldflags) -licuuc -lboost_system
+MAPNIK_LDFLAGS=$(shell mapnik-config --libs --dep-libs --ldflags)
 CXXFLAGS := $(CXXFLAGS) # inherit from env
 LDFLAGS := $(LDFLAGS) # inherit from env
 


### PR DESCRIPTION
The immediate problem is that `-lagg` is missing from the link command, which means the test fails to link on systems that don't allow implicit linking against shared libraries.  It seemed more sensible to use `--dep-libs` rather than explicitly add another library to the link.
