### PR TITLE
Include mapnik/image_compositing.hpp for the composite function

### DIFF
--- a/src/vector_tile_processor.hpp
+++ b/src/vector_tile_processor.hpp
@@ -23,6 +23,7 @@
 #include <mapnik/warp.hpp>
 #include <mapnik/version.hpp>
 #include <mapnik/image_scaling.hpp>
+#include <mapnik/image_compositing.hpp>
 
 // agg
 #ifdef CONV_CLIPPER


### PR DESCRIPTION
I assume newer versions of mapnik must be pulling this in as a side effect of some other header, but with 2.2.0 it needs to be pulled in explicitly or node-mapnik fails to build complaining that `composite` can't be found.
