### PR TITLE
Adapt to latest vector tile spec

### DIFF
--- a/examples/c++/tileinfo.cpp
+++ b/examples/c++/tileinfo.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
         stream.close();
 
         // now attemp to open protobuf
-        mapnik::vector::tile tile;
+        vector_tile::Tile tile;
         if (mapnik::vector::is_compressed(message))
         {
             std::string uncompressed;
@@ -75,7 +75,7 @@ int main(int argc, char** argv)
             std::cout << "layers: " << tile.layers_size() << "\n";
             for (unsigned i=0;i<tile.layers_size();++i)
             {
-                mapnik::vector::tile_layer const& layer = tile.layers(i);
+                vector_tile::Tile_Layer const& layer = tile.layers(i);
                 std::cout << layer.name() << ":\n";
                 std::cout << "  version: " << layer.version() << "\n";
                 std::cout << "  extent: " << layer.extent() << "\n";
@@ -91,7 +91,7 @@ int main(int argc, char** argv)
                 unsigned degenerate = 0;
                 for (unsigned j=0;j<layer.features_size();++j)
                 {
-                    mapnik::vector::tile_feature const & f = layer.features(j);
+                    vector_tile::Tile_Feature const & f = layer.features(j);
                     total_repeated += f.geometry_size();
                     eGeomType g_type = static_cast<eGeomType>(f.type());
                     int cmd = -1;
@@ -150,7 +150,7 @@ int main(int argc, char** argv)
         } else {
             for (unsigned i=0;i<tile.layers_size();++i)
             {
-                mapnik::vector::tile_layer const& layer = tile.layers(i);
+                vector_tile::Tile_Layer const& layer = tile.layers(i);
                 std::cout << "layer: " << layer.name() << "\n";
                 std::cout << "  version: " << layer.version() << "\n";
                 std::cout << "  extent: " << layer.extent() << "\n";
@@ -167,7 +167,7 @@ int main(int argc, char** argv)
                 std::cout << "  values: ";
                 for (unsigned i=0;i<layer.values_size();++i)
                 {
-                     mapnik::vector::tile_value const & value = layer.values(i);
+                     vector_tile::Tile_Value const & value = layer.values(i);
                      if (value.has_string_value()) {
                           std::cout << value.string_value();
                      } else if (value.has_int_value()) {
@@ -192,7 +192,7 @@ int main(int argc, char** argv)
                  std::cout << "\n";
                  for (unsigned i=0;i<layer.features_size();++i)
                  {
-                     mapnik::vector::tile_feature const & feat = layer.features(i);
+                     vector_tile::Tile_Feature const & feat = layer.features(i);
                      std::cout << "  feature: " << feat.id() << "\n";
                      std::cout << "    type: ";
                      unsigned feat_type = feat.type();

--- a/proto/vector_tile.proto
+++ b/proto/vector_tile.proto
@@ -1,19 +1,19 @@
 // Protocol Version 1
 
-package mapnik.vector;
+package vector_tile;
 
 option optimize_for = LITE_RUNTIME;
 
-message tile {
+message Tile {
         enum GeomType {
-             Unknown = 0;
-             Point = 1;
-             LineString = 2;
-             Polygon = 3;
+             UNKNOWN = 0;
+             POINT = 1;
+             LINESTRING = 2;
+             POLYGON = 3;
         }
 
         // Variant type encoding
-        message value {
+        message Value {
                 // Exactly one of these values may be present in a valid message
                 optional string string_value = 1;
                 optional float float_value = 2;
@@ -26,17 +26,20 @@ message tile {
                 extensions 8 to max;
         }
 
-        message feature {
-                optional uint64 id = 1;
+        message Feature {
+                optional uint64 id = 1 [ default = 0 ];
 
-                // Tags of this feature. Even numbered values refer to the nth
-                // value in the keys list on the tile message, odd numbered
-                // values refer to the nth value in the values list on the tile
-                // message.
+                // Tags of this feature are encoded as repeated pairs of
+                // integers. Even indexed values (n, beginning with 0) are
+                // themselves indexes into the layer's keys list. Odd indexed
+                // values (n+1) are indexes into the layer's values list.
+                // The first (n=0) tag of a feature, therefore, has a key of
+                // layer.keys[feature.tags[0]] and a value of
+                // layer.values[feature.tags[1]].
                 repeated uint32 tags = 2 [ packed = true ];
 
                 // The type of geometry stored in this feature.
-                optional GeomType type = 3 [ default = Unknown ];
+                optional GeomType type = 3 [ default = UNKNOWN ];
 
                 // Contains a stream of commands and parameters (vertices). The
                 // repeat count is shifted to the left by 3 bits. This means
@@ -47,25 +50,29 @@ message tile {
                 // - LineTo:    2   (2 parameters follow)
                 // - ClosePath: 7   (no parameters follow)
                 //
+                // Commands are encoded as uint32 varints. Vertex parameters
+                // are encoded as deltas to the previous position and, as they
+                // may be negative, are further "zigzag" encoded as unsigned
+                // 32-bit ints:
+                //
+                //   n = (n << 1) ^ (n >> 31)
+                //
                 // Ex.: MoveTo(3, 6), LineTo(8, 12), LineTo(20, 34), ClosePath
-                // Encoded as: [ 9 3 6 18 5 6 12 22 15 ]
-                //                                  == command type 7 (ClosePath), length 1
-                //                             ===== relative LineTo(+12, +22) == LineTo(20, 34)
-                //                         === relative LineTo(+5, +6) == LineTo(8, 12)
-                //                      == [00010 010] = command type 2 (LineTo), length 2
-                //                  === relative MoveTo(+3, +6)
-                //              == [00001 001] = command type 1 (MoveTo), length 1
-                // Commands are encoded as uint32 varints, vertex parameters are
-                // encoded as sint32 varints (zigzag). Vertex parameters are
-                // also encoded as deltas to the previous position. The original
-                // position is (0,0)
+                // Encoded as: [ 9 6 12 18 10 12 24 44 15 ]
+                //               |       |              `> [00001 111] command type 7 (ClosePath), length 1
+                //               |       |       ===== relative LineTo(+12, +22) == LineTo(20, 34)
+                //               |       | ===== relative LineTo(+5, +6) == LineTo(8, 12)
+                //               |       `> [00010 010] = command type 2 (LineTo), length 2
+                //               | ==== relative MoveTo(+3, +6)
+                //               `> [00001 001] = command type 1 (MoveTo), length 1
+                //
+                // The original position is (0,0).
                 repeated uint32 geometry = 4 [ packed = true ];
 
                 optional bytes raster = 5;
-
         }
 
-        message layer {
+        message Layer {
                 // Any compliant implementation must first read the version
                 // number encoded in this message and choose the correct
                 // implementation for this version number before proceeding to
@@ -75,13 +82,13 @@ message tile {
                 required string name = 1;
 
                 // The actual features in this tile.
-                repeated feature features = 2;
+                repeated Feature features = 2;
 
                 // Dictionary encoding for keys
                 repeated string keys = 3;
 
                 // Dictionary encoding for values
-                repeated value values = 4;
+                repeated Value values = 4;
 
                 // The bounding box in this tile spans from 0..4095 units
                 optional uint32 extent = 5 [ default = 4096 ];
@@ -89,7 +96,7 @@ message tile {
                 extensions 16 to max;
         }
 
-        repeated layer layers = 3;
+        repeated Layer layers = 3;
 
         extensions 16 to 8191;
 }

--- a/src/vector_tile_backend_pbf.hpp
+++ b/src/vector_tile_backend_pbf.hpp
@@ -19,12 +19,12 @@
 
 #include MAPNIK_VARIANT_INCLUDE
 
-namespace mapnik { namespace vector {
+namespace mapnik { namespace vector_tile_impl {
 
     struct to_tile_value: public MAPNIK_STATIC_VISITOR<>
     {
     public:
-        to_tile_value(tile_value * value):
+        to_tile_value(vector_tile::Tile_Value * value):
             value_(value) {}
 
         void operator () ( value_integer val ) const
@@ -56,7 +56,7 @@ namespace mapnik { namespace vector {
             // do nothing
         }
     private:
-        tile_value * value_;
+        vector_tile::Tile_Value * value_;
     };
 
     struct backend_pbf
@@ -64,15 +64,15 @@ namespace mapnik { namespace vector {
         typedef std::map<std::string, unsigned> keys_container;
         typedef boost::unordered_map<mapnik::value, unsigned> values_container;
     private:
-        tile & tile_;
+        vector_tile::Tile & tile_;
         unsigned path_multiplier_;
-        mutable tile_layer * current_layer_;
-        mutable tile_feature * current_feature_;
+        mutable vector_tile::Tile_Layer * current_layer_;
+        mutable vector_tile::Tile_Feature * current_feature_;
         keys_container keys_;
         values_container values_;
         int32_t x_, y_;
     public:
-        explicit backend_pbf(tile & _tile,
+        explicit backend_pbf(vector_tile::Tile & _tile,
                              unsigned path_multiplier)
             : tile_(_tile),
               path_multiplier_(path_multiplier),
@@ -175,7 +175,7 @@ namespace mapnik { namespace vector {
 
         inline void stop_tile_layer()
         {
-            //std::cerr << "stop_tile_layer()" << std::endl;
+            //std::cerr << "stop_vector_tile::Tile_Layer()" << std::endl;
         }
 
         template <typename T>
@@ -184,7 +184,7 @@ namespace mapnik { namespace vector {
             if (current_feature_)
             {
                 return encode_geometry(path,
-                                       static_cast<tile_GeomType>(type),
+                                       static_cast<vector_tile::Tile_GeomType>(type),
                                        *current_feature_,
                                        x_,
                                        y_,

--- a/src/vector_tile_compression.hpp
+++ b/src/vector_tile_compression.hpp
@@ -1,7 +1,7 @@
 #include <stdexcept>
 #include <zlib.h>
 
-namespace mapnik { namespace vector {
+namespace mapnik { namespace vector_tile_impl {
 
 inline bool is_compressed(std::string const& data)
 {

--- a/src/vector_tile_datasource.hpp
+++ b/src/vector_tile_datasource.hpp
@@ -36,11 +36,11 @@
 #include MAPNIK_SHARED_INCLUDE
 #include MAPNIK_VIEW_TRANSFORM_INCLUDE
 
-namespace mapnik { namespace vector {
+namespace mapnik { namespace vector_tile_impl {
 
     void add_attributes(mapnik::feature_ptr feature,
-                        mapnik::vector::tile_feature const& f,
-                        mapnik::vector::tile_layer const& layer,
+                        vector_tile::Tile_Feature const& f,
+                        vector_tile::Tile_Layer const& layer,
                         mapnik::transcoder const& tr)
     {
         std::size_t num_keys = static_cast<std::size_t>(layer.keys_size());
@@ -55,7 +55,7 @@ namespace mapnik { namespace vector {
                 std::string const& name = layer.keys(key_name);
                 if (feature->has_key(name))
                 {
-                    mapnik::vector::tile_value const& value = layer.values(key_value);
+                    vector_tile::Tile_Value const& value = layer.values(key_value);
                     if (value.has_string_value())
                     {
                         std::string str = value.string_value();
@@ -98,7 +98,7 @@ namespace mapnik { namespace vector {
                         mapnik::box2d<double> const& tile_extent,
                         mapnik::box2d<double> const& unbuffered_query,
                         std::set<std::string> const& attribute_names,
-                        mapnik::vector::tile_layer const& layer,
+                        vector_tile::Tile_Layer const& layer,
                         double tile_x,
                         double tile_y,
                         double scale)
@@ -135,7 +135,7 @@ namespace mapnik { namespace vector {
         {
             while (itr_ < end_)
             {
-                mapnik::vector::tile_feature const& f = layer_.features(itr_);
+                vector_tile::Tile_Feature const& f = layer_.features(itr_);
                 mapnik::value_integer feature_id = itr_++;
                 if (f.has_raster())
                 {
@@ -281,7 +281,7 @@ namespace mapnik { namespace vector {
         Filter filter_;
         mapnik::box2d<double> tile_extent_;
         mapnik::box2d<double> unbuffered_query_;
-        mapnik::vector::tile_layer const& layer_;
+        vector_tile::Tile_Layer const& layer_;
         double tile_x_;
         double tile_y_;
         double scale_;
@@ -294,7 +294,7 @@ namespace mapnik { namespace vector {
     class tile_datasource : public datasource
     {
     public:
-        tile_datasource(mapnik::vector::tile_layer const& layer,
+        tile_datasource(vector_tile::Tile_Layer const& layer,
                         unsigned x,
                         unsigned y,
                         unsigned z,
@@ -311,7 +311,7 @@ namespace mapnik { namespace vector {
     private:
         mutable mapnik::layer_descriptor desc_;
         mutable bool attributes_added_;
-        mapnik::vector::tile_layer const& layer_;
+        vector_tile::Tile_Layer const& layer_;
         unsigned x_;
         unsigned y_;
         unsigned z_;
@@ -324,7 +324,7 @@ namespace mapnik { namespace vector {
     };
 
 // tile_datasource impl
-    inline tile_datasource::tile_datasource(mapnik::vector::tile_layer const& layer,
+    inline tile_datasource::tile_datasource(vector_tile::Tile_Layer const& layer,
                                      unsigned x,
                                      unsigned y,
                                      unsigned z,
@@ -378,7 +378,7 @@ namespace mapnik { namespace vector {
 
     inline box2d<double> tile_datasource::get_tile_extent() const
     {
-        mapnik::vector::spherical_mercator merc(tile_size_);
+        spherical_mercator merc(tile_size_);
         double minx,miny,maxx,maxy;
         merc.xyz(x_,y_,z_,minx,miny,maxx,maxy);
         return box2d<double>(minx,miny,maxx,maxy);

--- a/src/vector_tile_geometry_encoder.hpp
+++ b/src/vector_tile_geometry_encoder.hpp
@@ -6,9 +6,9 @@
 #include <mapnik/vertex.hpp>
 #include <mapnik/version.hpp>
 
-namespace mapnik { namespace vector {
+namespace mapnik { namespace vector_tile_impl {
 
-inline void handle_skipped_last(tile_feature & current_feature,
+inline void handle_skipped_last(vector_tile::Tile_Feature & current_feature,
                                 int32_t skipped_index,
                                 int32_t cur_x,
                                 int32_t cur_y,
@@ -29,8 +29,8 @@ inline void handle_skipped_last(tile_feature & current_feature,
 
 template <typename T>
 unsigned encode_geometry(T & path,
-                         tile_GeomType type,
-                         tile_feature & current_feature,
+                         vector_tile::Tile_GeomType type,
+                         vector_tile::Tile_Feature & current_feature,
                          int32_t & x_,
                          int32_t & y_,
                          unsigned tolerance,

--- a/src/vector_tile_processor.hpp
+++ b/src/vector_tile_processor.hpp
@@ -50,7 +50,7 @@
 #include MAPNIK_VIEW_TRANSFORM_INCLUDE
 #include MAPNIK_TRANSFORM_PATH_INCLUDE
 
-namespace mapnik { namespace vector {
+namespace mapnik { namespace vector_tile_impl {
 
 
 /*

--- a/src/vector_tile_projection.hpp
+++ b/src/vector_tile_projection.hpp
@@ -9,7 +9,7 @@
 #define M_PI 3.141592653589793238462643
 #endif
 
-namespace mapnik { namespace vector {
+namespace mapnik { namespace vector_tile_impl {
 
     class spherical_mercator
     {

--- a/src/vector_tile_util.hpp
+++ b/src/vector_tile_util.hpp
@@ -12,16 +12,16 @@
 #include "clipper.hpp"
 #endif
 
-namespace mapnik { namespace vector {
+namespace mapnik { namespace vector_tile_impl {
 
 #ifdef CONV_CLIPPER
-    bool is_solid_clipper(mapnik::vector::tile const& tile, std::string & key)
+    bool is_solid_clipper(vector_tile::Tile const& tile, std::string & key)
     {
         ClipperLib::Clipper clipper;
 
         for (int i = 0; i < tile.layers_size(); i++)
         {
-            mapnik::vector::tile_layer const& layer = tile.layers(i);
+            vector_tile::Tile_Layer const& layer = tile.layers(i);
             unsigned extent = layer.extent();
             unsigned side = extent - 1;
             double extent_area = side * side;
@@ -35,7 +35,7 @@ namespace mapnik { namespace vector {
 
             for (int j = 0; j < layer.features_size(); j++)
             {
-                mapnik::vector::tile_feature const& feature = layer.features(j);
+                vector_tile::Tile_Feature const& feature = layer.features(j);
 
                 int cmd = -1;
                 const int cmd_bits = 3;
@@ -183,11 +183,11 @@ namespace mapnik { namespace vector {
         return false;
     }
 
-    bool is_solid_extent(mapnik::vector::tile const& tile, std::string & key)
+    bool is_solid_extent(vector_tile::Tile const& tile, std::string & key)
     {
         for (int i = 0; i < tile.layers_size(); i++)
         {
-            mapnik::vector::tile_layer const& layer = tile.layers(i);
+            vector_tile::Tile_Layer const& layer = tile.layers(i);
             unsigned extent = layer.extent();
             unsigned side = extent - 1;
             // TODO: need to account for buffer here
@@ -197,7 +197,7 @@ namespace mapnik { namespace vector {
             double extent_area = side * side;
             for (int j = 0; j < layer.features_size(); j++)
             {
-                mapnik::vector::tile_feature const& feature = layer.features(j);
+                vector_tile::Tile_Feature const& feature = layer.features(j);
                 int cmd = -1;
                 const int cmd_bits = 3;
                 unsigned length = 0;

--- a/test/encoding_util.hpp
+++ b/test/encoding_util.hpp
@@ -2,7 +2,7 @@
 #include <mapnik/geometry.hpp>
 #include "vector_tile_geometry_encoder.hpp"
 
-void decode_geometry(mapnik::vector::tile_feature const& f,
+void decode_geometry(vector_tile::Tile_Feature const& f,
                      mapnik::geometry_type & geom,
                      double & x,
                      double & y,
@@ -71,12 +71,12 @@ std::string compare(mapnik::geometry_type const & g,
                     unsigned tolerance=0,
                     unsigned path_multiplier=1)
 {
-    using namespace mapnik::vector;
+    using namespace mapnik::vector_tile_impl;
     // encode
-    tile_feature feature;
+    vector_tile::Tile_Feature feature;
     int32_t x = 0;
     int32_t y = 0;
-    encode_geometry(g,(tile_GeomType)g.type(),feature,x,y,tolerance,path_multiplier);
+    encode_geometry(g,(vector_tile::Tile_GeomType)g.type(),feature,x,y,tolerance,path_multiplier);
     // decode
     mapnik::geometry_type g2(MAPNIK_POLYGON);
     double x0 = 0;

--- a/test/geometry_encoding.cpp
+++ b/test/geometry_encoding.cpp
@@ -244,8 +244,8 @@ TEST_CASE( "test 10", "should skip repeated close and coincident line_to command
 }
 
 TEST_CASE( "test 11", "should correctly encode multiple paths" ) {
-    using namespace mapnik::vector;
-    tile_feature feature0;
+    using namespace mapnik::vector_tile_impl;
+    vector_tile::Tile_Feature feature0;
     int32_t x = 0;
     int32_t y = 0;
     unsigned path_multiplier = 1;
@@ -255,7 +255,7 @@ TEST_CASE( "test 11", "should correctly encode multiple paths" ) {
     g0.line_to(-10,-10);
     g0.line_to(-20,-20);
     g0.close_path();
-    encode_geometry(g0,(tile_GeomType)g0.type(),feature0,x,y,tolerance,path_multiplier);
+    encode_geometry(g0,(vector_tile::Tile_GeomType)g0.type(),feature0,x,y,tolerance,path_multiplier);
     CHECK(x == -20);
     CHECK(y == -20);
     mapnik::geometry_type g1(MAPNIK_POLYGON);
@@ -263,7 +263,7 @@ TEST_CASE( "test 11", "should correctly encode multiple paths" ) {
     g1.line_to(1010,1010);
     g1.line_to(1020,1020);
     g1.close_path();
-    encode_geometry(g1,(tile_GeomType)g1.type(),feature0,x,y,tolerance,path_multiplier);
+    encode_geometry(g1,(vector_tile::Tile_GeomType)g1.type(),feature0,x,y,tolerance,path_multiplier);
     CHECK(x == 1020);
     CHECK(y == 1020);
     mapnik::geometry_type g2(MAPNIK_POLYGON);
@@ -283,8 +283,8 @@ TEST_CASE( "test 11", "should correctly encode multiple paths" ) {
 }
 
 TEST_CASE( "test 12", "should correctly encode multiple paths" ) {
-    using namespace mapnik::vector;
-    tile_feature feature0;
+    using namespace mapnik::vector_tile_impl;
+    vector_tile::Tile_Feature feature0;
     int32_t x = 0;
     int32_t y = 0;
     unsigned path_multiplier = 1;
@@ -304,7 +304,7 @@ TEST_CASE( "test 12", "should correctly encode multiple paths" ) {
     g.line_to(25,20);
     g.line_to(20,20);
     g.close_path();
-    encode_geometry(g,(tile_GeomType)g.type(),feature0,x,y,tolerance,path_multiplier);
+    encode_geometry(g,(vector_tile::Tile_GeomType)g.type(),feature0,x,y,tolerance,path_multiplier);
 
     mapnik::geometry_type g2(MAPNIK_POLYGON);
     double x0 = 0;

--- a/test/raster_tile.cpp
+++ b/test/raster_tile.cpp
@@ -21,12 +21,12 @@
 
 TEST_CASE( "vector tile output 1", "should create vector tile with one raster layer" ) {
     mapnik::datasource_cache::instance().register_datasources(MAPNIK_PLUGINDIR);
-    typedef mapnik::vector::backend_pbf backend_type;
-    typedef mapnik::vector::processor<backend_type> renderer_type;
-    typedef mapnik::vector::tile tile_type;
+    typedef mapnik::vector_tile_impl::backend_pbf backend_type;
+    typedef mapnik::vector_tile_impl::processor<backend_type> renderer_type;
+    typedef vector_tile::Tile tile_type;
     unsigned _x=0,_y=0,_z=1;
     double minx,miny,maxx,maxy;
-    mapnik::vector::spherical_mercator merc(512);
+    mapnik::vector_tile_impl::spherical_mercator merc(512);
     merc.xyz(_x,_y,_z,minx,miny,maxx,maxy);
     mapnik::box2d<double> bbox;
     bbox.init(minx,miny,maxx,maxy);
@@ -51,13 +51,13 @@ TEST_CASE( "vector tile output 1", "should create vector tile with one raster la
     renderer_type ren(backend,map,m_req,1.0,0,0,1,"jpeg",mapnik::SCALING_BILINEAR);
     ren.apply();
     std::string key("");
-    CHECK(false == is_solid_extent(tile,key));
+    CHECK(false == mapnik::vector_tile_impl::is_solid_extent(tile,key));
     CHECK("" == key);
     CHECK(1 == tile.layers_size());
-    mapnik::vector::tile_layer const& layer = tile.layers(0);
+    vector_tile::Tile_Layer const& layer = tile.layers(0);
     CHECK(std::string("layer") == layer.name());
     CHECK(1 == layer.features_size());
-    mapnik::vector::tile_feature const& f = layer.features(0);
+    vector_tile::Tile_Feature const& f = layer.features(0);
     CHECK(static_cast<mapnik::value_integer>(1) == static_cast<mapnik::value_integer>(f.id()));
     CHECK(0 == f.geometry_size());
     CHECK(f.has_raster());
@@ -103,13 +103,13 @@ TEST_CASE( "vector tile output 1", "should create vector tile with one raster la
     tile_type tile2;
     CHECK(tile2.ParseFromString(buffer));
     std::string key2("");
-    CHECK(false == is_solid_extent(tile,key2));
+    CHECK(false == mapnik::vector_tile_impl::is_solid_extent(tile,key2));
     CHECK("" == key2);
     CHECK(1 == tile2.layers_size());
-    mapnik::vector::tile_layer const& layer2 = tile2.layers(0);
+    vector_tile::Tile_Layer const& layer2 = tile2.layers(0);
     CHECK(std::string("layer") == layer2.name());
     CHECK(1 == layer2.features_size());
-    mapnik::vector::tile_feature const& f2 = layer2.features(0);
+    vector_tile::Tile_Feature const& f2 = layer2.features(0);
     CHECK(static_cast<mapnik::value_integer>(1) == static_cast<mapnik::value_integer>(f2.id()));
     CHECK(0 == f2.geometry_size());
     CHECK(f2.has_raster());
@@ -118,8 +118,8 @@ TEST_CASE( "vector tile output 1", "should create vector tile with one raster la
         CHECK(expected_image_size == f2.raster().size());
     }
     mapnik::layer lyr2("layer",map2.srs());
-    MAPNIK_SHARED_PTR<mapnik::vector::tile_datasource> ds2 = MAPNIK_MAKE_SHARED<
-                                    mapnik::vector::tile_datasource>(
+    MAPNIK_SHARED_PTR<mapnik::vector_tile_impl::tile_datasource> ds2 = MAPNIK_MAKE_SHARED<
+                                    mapnik::vector_tile_impl::tile_datasource>(
                                         layer2,_x,_y,_z,map2.width());
     lyr2.set_datasource(ds2);
     lyr2.add_style("style");
@@ -141,13 +141,13 @@ TEST_CASE( "vector tile output 1", "should create vector tile with one raster la
 
 TEST_CASE( "vector tile output 2", "should be able to overzoom raster" ) {
     mapnik::datasource_cache::instance().register_datasources(MAPNIK_PLUGINDIR);
-    typedef mapnik::vector::tile tile_type;
+    typedef vector_tile::Tile tile_type;
     tile_type tile;
     {
-        typedef mapnik::vector::backend_pbf backend_type;
-        typedef mapnik::vector::processor<backend_type> renderer_type;
+        typedef mapnik::vector_tile_impl::backend_pbf backend_type;
+        typedef mapnik::vector_tile_impl::processor<backend_type> renderer_type;
         double minx,miny,maxx,maxy;
-        mapnik::vector::spherical_mercator merc(256);
+        mapnik::vector_tile_impl::spherical_mercator merc(256);
         merc.xyz(0,0,0,minx,miny,maxx,maxy);
         mapnik::box2d<double> bbox(minx,miny,maxx,maxy);
         backend_type backend(tile,16);
@@ -173,10 +173,10 @@ TEST_CASE( "vector tile output 2", "should be able to overzoom raster" ) {
     }
     // Done creating test data, now test created tile
     CHECK(1 == tile.layers_size());
-    mapnik::vector::tile_layer const& layer = tile.layers(0);
+    vector_tile::Tile_Layer const& layer = tile.layers(0);
     CHECK(std::string("layer") == layer.name());
     CHECK(1 == layer.features_size());
-    mapnik::vector::tile_feature const& f = layer.features(0);
+    vector_tile::Tile_Feature const& f = layer.features(0);
     CHECK(static_cast<mapnik::value_integer>(1) == static_cast<mapnik::value_integer>(f.id()));
     CHECK(0 == f.geometry_size());
     CHECK(f.has_raster());
@@ -205,10 +205,10 @@ TEST_CASE( "vector tile output 2", "should be able to overzoom raster" ) {
     tile_type tile2;
     CHECK(tile2.ParseFromString(buffer));
     CHECK(1 == tile2.layers_size());
-    mapnik::vector::tile_layer const& layer2 = tile2.layers(0);
+    vector_tile::Tile_Layer const& layer2 = tile2.layers(0);
     CHECK(std::string("layer") == layer2.name());
     CHECK(1 == layer2.features_size());
-    mapnik::vector::tile_feature const& f2 = layer2.features(0);
+    vector_tile::Tile_Feature const& f2 = layer2.features(0);
     CHECK(static_cast<mapnik::value_integer>(1) == static_cast<mapnik::value_integer>(f2.id()));
     CHECK(0 == f2.geometry_size());
     CHECK(f2.has_raster());
@@ -220,15 +220,15 @@ TEST_CASE( "vector tile output 2", "should be able to overzoom raster" ) {
     // now read back and render image at larger size
     // and zoomed in
     double minx,miny,maxx,maxy;
-    mapnik::vector::spherical_mercator merc(256);
+    mapnik::vector_tile_impl::spherical_mercator merc(256);
     // 2/0/1.png
     merc.xyz(0,1,2,minx,miny,maxx,maxy);
     mapnik::box2d<double> bbox(minx,miny,maxx,maxy);
     mapnik::Map map2(256,256,"+init=epsg:3857");
     map2.set_buffer_size(1024);
     mapnik::layer lyr2("layer",map2.srs());
-    MAPNIK_SHARED_PTR<mapnik::vector::tile_datasource> ds2 = MAPNIK_MAKE_SHARED<
-                                    mapnik::vector::tile_datasource>(
+    MAPNIK_SHARED_PTR<mapnik::vector_tile_impl::tile_datasource> ds2 = MAPNIK_MAKE_SHARED<
+                                    mapnik::vector_tile_impl::tile_datasource>(
                                         layer2,0,0,0,256);
     lyr2.set_datasource(ds2);
     lyr2.add_style("style");

--- a/test/vector_tile.cpp
+++ b/test/vector_tile.cpp
@@ -25,9 +25,9 @@ mapnik::box2d<double> bbox;
 
 /*
 TEST_CASE( "vector tile negative id", "hmm" ) {
-    mapnik::vector::tile tile;
-    mapnik::vector::tile_layer * layer = tile.add_layers();
-    mapnik::vector::tile_feature * feat = layer->add_features();
+    vector_tile::Tile tile;
+    vector_tile::Tile_Layer * layer = tile.add_layers();
+    vector_tile::Tile_Feature * feat = layer->add_features();
     feat->set_id(-1);
     std::clog << feat->id() << "\n";
     //CHECK(std::fabs(map_extent.maxy() - e.maxy()) < epsilon);
@@ -35,7 +35,7 @@ TEST_CASE( "vector tile negative id", "hmm" ) {
 */
 
 TEST_CASE( "vector tile projection 1", "should support z/x/y to bbox conversion at 0/0/0" ) {
-    mapnik::vector::spherical_mercator merc(256);
+    mapnik::vector_tile_impl::spherical_mercator merc(256);
     double minx,miny,maxx,maxy;
     merc.xyz(_x,_y,_z,minx,miny,maxx,maxy);
     mapnik::box2d<double> map_extent(minx,miny,maxx,maxy);
@@ -48,7 +48,7 @@ TEST_CASE( "vector tile projection 1", "should support z/x/y to bbox conversion 
 }
 
 TEST_CASE( "vector tile projection 2", "should support z/x/y to bbox conversion up to z33" ) {
-    mapnik::vector::spherical_mercator merc(256);
+    mapnik::vector_tile_impl::spherical_mercator merc(256);
     int x = 2145960701;
     int y = 1428172928;
     int z = 32;
@@ -64,9 +64,9 @@ TEST_CASE( "vector tile projection 2", "should support z/x/y to bbox conversion 
 }
 
 TEST_CASE( "vector tile output 1", "should create vector tile with two points" ) {
-    typedef mapnik::vector::backend_pbf backend_type;
-    typedef mapnik::vector::processor<backend_type> renderer_type;
-    typedef mapnik::vector::tile tile_type;
+    typedef mapnik::vector_tile_impl::backend_pbf backend_type;
+    typedef mapnik::vector_tile_impl::processor<backend_type> renderer_type;
+    typedef vector_tile::Tile tile_type;
     tile_type tile;
     backend_type backend(tile,16);
     mapnik::Map map(tile_size,tile_size,"+init=epsg:3857");
@@ -77,13 +77,13 @@ TEST_CASE( "vector tile output 1", "should create vector tile with two points" )
     renderer_type ren(backend,map,m_req);
     ren.apply();
     std::string key("");
-    CHECK(false == is_solid_extent(tile,key));
+    CHECK(false == mapnik::vector_tile_impl::is_solid_extent(tile,key));
     CHECK("" == key);
     CHECK(1 == tile.layers_size());
-    mapnik::vector::tile_layer const& layer = tile.layers(0);
+    vector_tile::Tile_Layer const& layer = tile.layers(0);
     CHECK(std::string("layer") == layer.name());
     CHECK(2 == layer.features_size());
-    mapnik::vector::tile_feature const& f = layer.features(0);
+    vector_tile::Tile_Feature const& f = layer.features(0);
     CHECK(static_cast<mapnik::value_integer>(1) == static_cast<mapnik::value_integer>(f.id()));
     CHECK(3 == f.geometry_size());
     CHECK(9 == f.geometry(0));
@@ -96,9 +96,9 @@ TEST_CASE( "vector tile output 1", "should create vector tile with two points" )
 }
 
 TEST_CASE( "vector tile output 2", "adding empty layers should result in empty tile" ) {
-    typedef mapnik::vector::backend_pbf backend_type;
-    typedef mapnik::vector::processor<backend_type> renderer_type;
-    typedef mapnik::vector::tile tile_type;
+    typedef mapnik::vector_tile_impl::backend_pbf backend_type;
+    typedef mapnik::vector_tile_impl::processor<backend_type> renderer_type;
+    typedef vector_tile::Tile tile_type;
     tile_type tile;
     backend_type backend(tile,16);
     mapnik::Map map(tile_size,tile_size,"+init=epsg:3857");
@@ -108,15 +108,15 @@ TEST_CASE( "vector tile output 2", "adding empty layers should result in empty t
     renderer_type ren(backend,map,m_req);
     ren.apply();
     std::string key("");
-    CHECK(true == is_solid_extent(tile,key));
+    CHECK(true == mapnik::vector_tile_impl::is_solid_extent(tile,key));
     CHECK("" == key);
     CHECK(0 == tile.layers_size());
 }
 
 TEST_CASE( "vector tile output 3", "adding layers with geometries outside rendering extent should not add layer" ) {
-    typedef mapnik::vector::backend_pbf backend_type;
-    typedef mapnik::vector::processor<backend_type> renderer_type;
-    typedef mapnik::vector::tile tile_type;
+    typedef mapnik::vector_tile_impl::backend_pbf backend_type;
+    typedef mapnik::vector_tile_impl::processor<backend_type> renderer_type;
+    typedef vector_tile::Tile tile_type;
     tile_type tile;
     backend_type backend(tile,16);
     mapnik::Map map(tile_size,tile_size,"+init=epsg:3857");
@@ -143,15 +143,15 @@ TEST_CASE( "vector tile output 3", "adding layers with geometries outside render
     renderer_type ren(backend,map,m_req);
     ren.apply();
     std::string key("");
-    CHECK(true == is_solid_extent(tile,key));
+    CHECK(true == mapnik::vector_tile_impl::is_solid_extent(tile,key));
     CHECK("" == key);
     CHECK(0 == tile.layers_size());
 }
 
 TEST_CASE( "vector tile output 4", "adding layers with degenerate geometries should not add layer" ) {
-    typedef mapnik::vector::backend_pbf backend_type;
-    typedef mapnik::vector::processor<backend_type> renderer_type;
-    typedef mapnik::vector::tile tile_type;
+    typedef mapnik::vector_tile_impl::backend_pbf backend_type;
+    typedef mapnik::vector_tile_impl::processor<backend_type> renderer_type;
+    typedef vector_tile::Tile tile_type;
     tile_type tile;
     backend_type backend(tile,16);
     mapnik::Map map(tile_size,tile_size,"+init=epsg:3857");
@@ -168,15 +168,15 @@ TEST_CASE( "vector tile output 4", "adding layers with degenerate geometries sho
     renderer_type ren(backend,map,m_req);
     ren.apply();
     std::string key("");
-    CHECK(true == is_solid_extent(tile,key));
+    CHECK(true == mapnik::vector_tile_impl::is_solid_extent(tile,key));
     CHECK("" == key);
     CHECK(0 == tile.layers_size());
 }
 
 TEST_CASE( "vector tile input", "should be able to parse message and render point" ) {
-    typedef mapnik::vector::backend_pbf backend_type;
-    typedef mapnik::vector::processor<backend_type> renderer_type;
-    typedef mapnik::vector::tile tile_type;
+    typedef mapnik::vector_tile_impl::backend_pbf backend_type;
+    typedef mapnik::vector_tile_impl::processor<backend_type> renderer_type;
+    typedef vector_tile::Tile tile_type;
     tile_type tile;
     backend_type backend(tile,16);
     mapnik::Map map(tile_size,tile_size,"+init=epsg:3857");
@@ -196,16 +196,16 @@ TEST_CASE( "vector tile input", "should be able to parse message and render poin
     tile_type tile2;
     CHECK(tile2.ParseFromString(buffer));
     std::string key("");
-    CHECK(false == is_solid_extent(tile2,key));
+    CHECK(false == mapnik::vector_tile_impl::is_solid_extent(tile2,key));
     CHECK("" == key);
     CHECK(1 == tile2.layers_size());
-    mapnik::vector::tile_layer const& layer2 = tile2.layers(0);
+    vector_tile::Tile_Layer const& layer2 = tile2.layers(0);
     CHECK(std::string("layer") == layer2.name());
     CHECK(1 == layer2.features_size());
 
     mapnik::layer lyr2("layer",map.srs());
-    MAPNIK_SHARED_PTR<mapnik::vector::tile_datasource> ds = MAPNIK_MAKE_SHARED<
-                                    mapnik::vector::tile_datasource>(
+    MAPNIK_SHARED_PTR<mapnik::vector_tile_impl::tile_datasource> ds = MAPNIK_MAKE_SHARED<
+                                    mapnik::vector_tile_impl::tile_datasource>(
                                         layer2,_x,_y,_z,map2.width());
     ds->set_envelope(bbox);
     mapnik::layer_descriptor lay_desc = ds->get_descriptor();
@@ -237,9 +237,9 @@ TEST_CASE( "vector tile input", "should be able to parse message and render poin
 }
 
 TEST_CASE( "vector tile datasource", "should filter features outside extent" ) {
-    typedef mapnik::vector::backend_pbf backend_type;
-    typedef mapnik::vector::processor<backend_type> renderer_type;
-    typedef mapnik::vector::tile tile_type;
+    typedef mapnik::vector_tile_impl::backend_pbf backend_type;
+    typedef mapnik::vector_tile_impl::processor<backend_type> renderer_type;
+    typedef vector_tile::Tile tile_type;
     tile_type tile;
     backend_type backend(tile,16);
     mapnik::Map map(tile_size,tile_size,"+init=epsg:3857");
@@ -250,20 +250,20 @@ TEST_CASE( "vector tile datasource", "should filter features outside extent" ) {
     renderer_type ren(backend,map,m_req);
     ren.apply();
     std::string key("");
-    CHECK(false == is_solid_extent(tile,key));
+    CHECK(false == mapnik::vector_tile_impl::is_solid_extent(tile,key));
     CHECK("" == key);
     CHECK(1 == tile.layers_size());
-    mapnik::vector::tile_layer const& layer = tile.layers(0);
+    vector_tile::Tile_Layer const& layer = tile.layers(0);
     CHECK(std::string("layer") == layer.name());
     CHECK(1 == layer.features_size());
-    mapnik::vector::tile_feature const& f = layer.features(0);
+    vector_tile::Tile_Feature const& f = layer.features(0);
     CHECK(static_cast<mapnik::value_integer>(1) == static_cast<mapnik::value_integer>(f.id()));
     CHECK(3 == f.geometry_size());
     CHECK(9 == f.geometry(0));
     CHECK(4096 == f.geometry(1));
     CHECK(4096 == f.geometry(2));
     // now actually start the meat of the test
-    mapnik::vector::tile_datasource ds(layer,_x,_y,_z,tile_size);
+    mapnik::vector_tile_impl::tile_datasource ds(layer,_x,_y,_z,tile_size);
     mapnik::featureset_ptr fs;
 
     // ensure we can query single feature
@@ -324,8 +324,8 @@ TEST_CASE( "encoding multi line as one path", "should maintain second move_to co
     // the tolerance because we never want to drop a move_to or the first line_to
     unsigned tolerance = 2000000;
     // now create the testing data
-    mapnik::vector::tile tile;
-    mapnik::vector::backend_pbf backend(tile,path_multiplier);
+    vector_tile::Tile tile;
+    mapnik::vector_tile_impl::backend_pbf backend(tile,path_multiplier);
     backend.start_tile_layer("layer");
     mapnik::feature_ptr feature(mapnik::feature_factory::create(MAPNIK_MAKE_SHARED<mapnik::context_type>(),1));
     backend.start_tile_feature(*feature);
@@ -339,12 +339,12 @@ TEST_CASE( "encoding multi line as one path", "should maintain second move_to co
     backend.stop_tile_layer();
     // done encoding single feature/geometry
     std::string key("");
-    CHECK(false == is_solid_extent(tile,key));
+    CHECK(false == mapnik::vector_tile_impl::is_solid_extent(tile,key));
     CHECK("" == key);
     CHECK(1 == tile.layers_size());
-    mapnik::vector::tile_layer const& layer = tile.layers(0);
+    vector_tile::Tile_Layer const& layer = tile.layers(0);
     CHECK(1 == layer.features_size());
-    mapnik::vector::tile_feature const& f = layer.features(0);
+    vector_tile::Tile_Feature const& f = layer.features(0);
     CHECK(12 == f.geometry_size());
     CHECK(9 == f.geometry(0)); // 1 move_to
     CHECK(0 == f.geometry(1)); // x:0
@@ -370,8 +370,8 @@ TEST_CASE( "encoding single line 1", "should maintain start/end vertex" ) {
     // in both the x and y from the previous vertex
     unsigned tolerance = 2;
     // now create the testing data
-    mapnik::vector::tile tile;
-    mapnik::vector::backend_pbf backend(tile,path_multiplier);
+    vector_tile::Tile tile;
+    mapnik::vector_tile_impl::backend_pbf backend(tile,path_multiplier);
     backend.start_tile_layer("layer");
     mapnik::feature_ptr feature(mapnik::feature_factory::create(MAPNIK_MAKE_SHARED<mapnik::context_type>(),1));
     backend.start_tile_feature(*feature);
@@ -386,12 +386,12 @@ TEST_CASE( "encoding single line 1", "should maintain start/end vertex" ) {
     backend.stop_tile_layer();
     // done encoding single feature/geometry
     std::string key("");
-    CHECK(false == is_solid_extent(tile,key));
+    CHECK(false == mapnik::vector_tile_impl::is_solid_extent(tile,key));
     CHECK("" == key);
     CHECK(1 == tile.layers_size());
-    mapnik::vector::tile_layer const& layer = tile.layers(0);
+    vector_tile::Tile_Layer const& layer = tile.layers(0);
     CHECK(1 == layer.features_size());
-    mapnik::vector::tile_feature const& f = layer.features(0);
+    vector_tile::Tile_Feature const& f = layer.features(0);
     // sequence of 10 geometries given tolerance of 2
     CHECK(8 == f.geometry_size());
     // first geometry is 9, which packs both the command and how many verticies are encoded with that same command
@@ -430,15 +430,15 @@ TEST_CASE( "encoding single line 1", "should maintain start/end vertex" ) {
     CHECK(1998 == f.geometry(7));
 }
 
-// testcase for avoiding error in is_solid_extent of
+// testcase for avoiding error in mapnik::vector_tile_impl::is_solid_extent of
 // "Unknown command type (is_solid_extent): 0"
 // not yet clear if this test is correct
 // ported from shapefile test in tilelive-bridge (a:should render a (1.0.1))
 TEST_CASE( "encoding single line 2", "should maintain start/end vertex" ) {
     unsigned path_multiplier = 16;
     unsigned tolerance = 5;
-    mapnik::vector::tile tile;
-    mapnik::vector::backend_pbf backend(tile,path_multiplier);
+    vector_tile::Tile tile;
+    mapnik::vector_tile_impl::backend_pbf backend(tile,path_multiplier);
     backend.start_tile_layer("layer");
     mapnik::feature_ptr feature(mapnik::feature_factory::create(MAPNIK_MAKE_SHARED<mapnik::context_type>(),1));
     backend.start_tile_feature(*feature);
@@ -455,12 +455,12 @@ TEST_CASE( "encoding single line 2", "should maintain start/end vertex" ) {
     backend.stop_tile_feature();
     backend.stop_tile_layer();
     std::string key("");
-    CHECK(false == is_solid_extent(tile,key));
+    CHECK(false == mapnik::vector_tile_impl::is_solid_extent(tile,key));
     CHECK("" == key);
     CHECK(1 == tile.layers_size());
-    mapnik::vector::tile_layer const& layer = tile.layers(0);
+    vector_tile::Tile_Layer const& layer = tile.layers(0);
     CHECK(1 == layer.features_size());
-    mapnik::vector::tile_feature const& f = layer.features(0);
+    vector_tile::Tile_Feature const& f = layer.features(0);
     CHECK(7 == f.geometry_size());
 }
 
@@ -469,7 +469,7 @@ int main (int argc, char* const argv[])
     GOOGLE_PROTOBUF_VERIFY_VERSION;
     // set up bbox
     double minx,miny,maxx,maxy;
-    mapnik::vector::spherical_mercator merc(256);
+    mapnik::vector_tile_impl::spherical_mercator merc(256);
     merc.xyz(_x,_y,_z,minx,miny,maxx,maxy);
     bbox.init(minx,miny,maxx,maxy);
     int result = Catch::Session().run( argc, argv );


### PR DESCRIPTION
- pulls in the vector tile v1.0.1 spec (+ adds back experimental raster)
- moves to separate the `vector_tile` spec/protobuf namespace from the `mapnik::vector_tile_impl` on top of it.

Helper to cope with this renaming:

``` sh
for i in {"src","test","examples"}; do
    find $i -type f -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs perl -i -p -e "s/mapnik::vector::tile_layer/vector_tile::Tile_Layer/g"
    find $i -type f -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs perl -i -p -e "s/mapnik::vector::tile_feature/vector_tile::Tile_Feature/g"
    find $i -type f -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs perl -i -p -e "s/tile_layer/vector_tile::Tile_Layer/g"
    find $i -type f -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs perl -i -p -e "s/tile_feature/vector_tile::Tile_Feature/g"
    find $i -type f -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs perl -i -p -e "s/mapnik::vector::tile_value/vector_tile::Tile_Value/g"
    find $i -type f -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs perl -i -p -e "s/tile_value/vector_tile::Tile_Value/g"
    find $i -type f -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs perl -i -p -e "s/mapnik::vector::tile/vector_tile::Tile/g"
    find $i -type f -name '*.cpp' -or -name '*.h' -or -name '*.hpp' | xargs perl -i -p -e "s/tile_GeomType/vector_tile::Tile_GeomType/g"
done
```
