### PR TITLE
Start adapting to mapnik 'image_data_any' branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROTOBUF_CXXFLAGS=$(shell pkg-config protobuf --cflags)
 PROTOBUF_LDFLAGS=$(shell pkg-config protobuf --libs-only-L) -lprotobuf-lite
-MAPNIK_CXXFLAGS=$(shell mapnik-config --cflags) -Wsign-compare
+MAPNIK_CXXFLAGS=$(shell mapnik-config --cflags)
 MAPNIK_LDFLAGS=$(shell mapnik-config --libs --ldflags --dep-libs)
 COMMON_FLAGS = -Wall -pedantic -Wno-c++11-long-long -Wno-c++11-extensions -Wno-unknown-pragmas
 # -Wshadow -Wsign-compare -Wsign-conversion -Wunused-parameter

--- a/src/mapnik3x_compatibility.hpp
+++ b/src/mapnik3x_compatibility.hpp
@@ -24,6 +24,7 @@
     #define MAPNIK_VARIANT_INCLUDE <mapnik/util/variant.hpp>
     #define MAPNIK_APPLY_VISITOR mapnik::util::apply_visitor
     #define MAPNIK_STATIC_VISITOR mapnik::util::static_visitor
+    #define MAPNIK_IMAGE_RGBA mapnik::image_data_rgba8
 #else
     #define MAPNIK_TRANSFORM_PATH mapnik::coord_transform
     #define MAPNIK_TRANSFORM_PATH_INCLUDE <mapnik/ctrans.hpp>
@@ -44,6 +45,7 @@
     #define MAPNIK_VARIANT_INCLUDE <boost/variant.hpp>
     #define MAPNIK_APPLY_VISITOR boost::apply_visitor
     #define MAPNIK_STATIC_VISITOR boost::static_visitor
+    #define MAPNIK_IMAGE_RGBA mapnik::image_data_32
 #endif
 
 #endif

--- a/src/vector_tile_datasource.hpp
+++ b/src/vector_tile_datasource.hpp
@@ -182,17 +182,23 @@ namespace mapnik { namespace vector_tile_impl {
                                 intersect = t.backward(feature_raster_extent);
                                 #if MAPNIK_VERSION >= 300000
                                 double filter_factor = 1.0;
-                                #endif
-                                bool premultiplied = false;
+                                mapnik::image_data_any data = reader->read(x_off, y_off, width, height);
                                 mapnik::raster_ptr raster = MAPNIK_MAKE_SHARED<mapnik::raster>(intersect,
-                                                              width,
-                                                              height,
+                                                              data,
                                                               #if MAPNIK_VERSION >= 300000
                                                               filter_factor,
                                                               #endif
-                                                              premultiplied
+                                                              reader->premultiplied_alpha()
                                                               );
+                                #else
+                                bool premultiplied = false;
+                                mapnik::raster_ptr raster = MAPNIK_MAKE_SHARED<mapnik::raster>(intersect,
+                                                               width,
+                                                               height,
+                                                               premultiplied
+                                                               );
                                 reader->read(x_off, y_off, raster->data_);
+                                #endif
                                 mapnik::feature_ptr feature = mapnik::feature_factory::create(ctx_,feature_id);
                                 feature->set_raster(raster);
                                 add_attributes(feature,f,layer_,tr_);

--- a/test/compare_image.hpp
+++ b/test/compare_image.hpp
@@ -13,8 +13,8 @@ using namespace mapnik;
 
 namespace testing {
 
-    unsigned compare_images(image_data_32 const& src1,
-                            image_data_32 const& src2,
+    unsigned compare_images(MAPNIK_IMAGE_RGBA const& src1,
+                            MAPNIK_IMAGE_RGBA const& src2,
                             int threshold=16,
                             bool alpha=true)
     {
@@ -86,12 +86,12 @@ namespace testing {
         MAPNIK_SHARED_PTR<image_32> image_ptr2 = MAPNIK_MAKE_SHARED<image_32>(reader2->width(),reader2->height());
         reader2->read(0,0,image_ptr2->data());
 
-        image_data_32 const& src1 = image_ptr1->data();
-        image_data_32 const& src2 = image_ptr2->data();
+        MAPNIK_IMAGE_RGBA const& src1 = image_ptr1->data();
+        MAPNIK_IMAGE_RGBA const& src2 = image_ptr2->data();
         return compare_images(src1,src2,threshold,alpha);
     }
 
-    unsigned compare_images(image_data_32 const& src1,
+    unsigned compare_images(MAPNIK_IMAGE_RGBA const& src1,
                             std::string const& filepath,
                             int threshold=16,
                             bool alpha=true)
@@ -109,7 +109,7 @@ namespace testing {
         MAPNIK_SHARED_PTR<image_32> image_ptr2 = MAPNIK_MAKE_SHARED<image_32>(reader2->width(),reader2->height());
         reader2->read(0,0,image_ptr2->data());
 
-        image_data_32 const& src2 = image_ptr2->data();
+        MAPNIK_IMAGE_RGBA const& src2 = image_ptr2->data();
         return compare_images(src1,src2,threshold,alpha);
     }
 

--- a/test/raster_tile.cpp
+++ b/test/raster_tile.cpp
@@ -7,6 +7,8 @@
 #include "compare_image.hpp"
 #include "vector_tile_projection.hpp"
 
+#include "mapnik3x_compatibility.hpp"
+
 // vector output api
 #include "vector_tile_processor.hpp"
 #include "vector_tile_backend_pbf.hpp"
@@ -78,7 +80,7 @@ TEST_CASE( "vector tile output 1", "should create vector tile with one raster la
     if (!reader.get()) {
         throw std::runtime_error("could not open image bytes");
     }
-    mapnik::image_data_32 im_data(reader->width(),reader->height());
+    MAPNIK_IMAGE_RGBA im_data(reader->width(),reader->height());
     reader->read(0,0,im_data);
     unsigned diff = testing::compare_images(im_data,"test/fixtures/expected-2.jpeg");
     CHECK(0 == diff);


### PR DESCRIPTION
- all tests should still pass against Mapnik 2.3.x
- for now skips any image types besides rgba8
- next step: add tests and support for int8, int16, and float32
