### PR TITLE
Compile in C++11 mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROTOBUF_CXXFLAGS=$(shell pkg-config protobuf --cflags)
 PROTOBUF_LDFLAGS=$(shell pkg-config protobuf --libs-only-L) -lprotobuf-lite
 MAPNIK_CXXFLAGS=$(shell mapnik-config --cflags)
 MAPNIK_LDFLAGS=$(shell mapnik-config --libs --ldflags --dep-libs)
-COMMON_FLAGS = -Wall -pedantic -Wno-c++11-long-long -Wno-c++11-extensions -Wno-unknown-pragmas
+COMMON_FLAGS = -std=c++11 -Wall -pedantic -Wno-c++11-long-long -Wno-c++11-extensions -Wno-unknown-pragmas
 # -Wshadow -Wsign-compare -Wsign-conversion -Wunused-parameter
 # inherit from env
 CXX := $(CXX)


### PR DESCRIPTION
Set the compiler to C++11 mode as the tests use C++11 features and gcc 5 refuses to compile the code in it's default mode (C++98 mode).