### PR TITLE
Use mason packaged mapnik for travis builds and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,23 @@
 language: cpp
 
+sudo: false
+
+os:
+ - osx
+ - linux
+
 compiler:
- - clang
  - gcc
 
 before_install:
- - sudo apt-add-repository --yes ppa:mapnik/nightly-trunk
- - sudo apt-get update -y
+ - source ./bootstrap.sh
 
 install:
- - sudo apt-get -y install libprotobuf7 libprotobuf-dev protobuf-compiler libmapnik=3.0.0* mapnik-utils=3.0.0* libmapnik-dev=3.0.0* mapnik-input-plugin*=3.0.0* gcc-4.8 g++-4.8
+ - make test
 
 before_script:
- - if [ "${CXX}" = 'g++' ]; then export CXX="g++-4.8" && export CC="gcc-4.8"; fi;
+ - true
 
 script:
- - make clean
- - make test
  - cd examples/c++
  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ before_script:
 
 script:
  - cd examples/c++
- - make
+ # TODO - incorporate build into main makefile
+ #- make

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
  - linux
 
 compiler:
- - gcc
+ - clang
 
 before_install:
  - source ./bootstrap.sh

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PROTOBUF_CXXFLAGS=-D_THREAD_SAFE
+PROTOBUF_LDFLAGS=-lprotobuf-lite
 MAPNIK_CXXFLAGS=$(shell mapnik-config --cflags)
 MAPNIK_LDFLAGS=$(shell mapnik-config --libs --ldflags --dep-libs)
 COMMON_FLAGS = -Wall -pedantic -Wno-c++11-long-long -Wno-c++11-extensions -Wno-unknown-pragmas
@@ -16,7 +18,7 @@ src/vector_tile.pb.cc: proto/vector_tile.proto
 	protoc -Iproto/ --cpp_out=./src proto/vector_tile.proto
 
 test/run-test: Makefile src/vector_tile.pb.cc test/vector_tile.cpp test/test_utils.hpp src/*
-	$(CXX) -o ./test/run-test test/vector_tile.cpp src/vector_tile.pb.cc -I./src $(CXXFLAGS) $(MAPNIK_CXXFLAGS) $(COMMON_FLAGS) $(MAPNIK_LDFLAGS) $(LDFLAGS) -Wno-unused-private-field
+	$(CXX) -o ./test/run-test test/vector_tile.cpp src/vector_tile.pb.cc -I./src $(CXXFLAGS) $(MAPNIK_CXXFLAGS) $(PROTOBUF_CXXFLAGS) $(COMMON_FLAGS) $(MAPNIK_LDFLAGS) $(PROTOBUF_LDFLAGS) $(LDFLAGS) -Wno-unused-private-field
 
 test: test/run-test test/run-geom-test ./test/run-raster-test src/vector_tile.pb.cc test/catch.hpp
 	./test/run-test
@@ -24,11 +26,11 @@ test: test/run-test test/run-geom-test ./test/run-raster-test src/vector_tile.pb
 	./test/run-raster-test
 
 ./test/run-raster-test: Makefile src/vector_tile.pb.cc test/raster_tile.cpp test/encoding_util.hpp src/*
-	$(CXX) -o ./test/run-raster-test test/raster_tile.cpp src/vector_tile.pb.cc -DMAPNIK_PLUGINDIR=\"$(MAPNIK_PLUGINDIR)\" -I./src $(CXXFLAGS) $(MAPNIK_CXXFLAGS) $(COMMON_FLAGS) $(MAPNIK_LDFLAGS) $(LDFLAGS) -Wno-unused-private-field
+	$(CXX) -o ./test/run-raster-test test/raster_tile.cpp src/vector_tile.pb.cc -DMAPNIK_PLUGINDIR=\"$(MAPNIK_PLUGINDIR)\" -I./src $(CXXFLAGS) $(MAPNIK_CXXFLAGS) $(PROTOBUF_CXXFLAGS) $(COMMON_FLAGS) $(MAPNIK_LDFLAGS) $(PROTOBUF_LDFLAGS) $(LDFLAGS) -Wno-unused-private-field
 	./test/run-raster-test
 
 ./test/run-geom-test: Makefile src/vector_tile.pb.cc test/geometry_encoding.cpp test/encoding_util.hpp src/vector_tile_geometry_encoder.hpp src/*
-	@$(CXX) -o ./test/run-geom-test test/geometry_encoding.cpp src/vector_tile.pb.cc -I./src $(CXXFLAGS) $(MAPNIK_CXXFLAGS) $(COMMON_FLAGS) $(MAPNIK_LDFLAGS) $(LDFLAGS) -Wno-unused-private-field
+	@$(CXX) -o ./test/run-geom-test test/geometry_encoding.cpp src/vector_tile.pb.cc -I./src $(CXXFLAGS) $(MAPNIK_CXXFLAGS) $(PROTOBUF_CXXFLAGS) $(COMMON_FLAGS) $(MAPNIK_LDFLAGS) $(PROTOBUF_LDFLAGS) $(LDFLAGS) -Wno-unused-private-field
 
 geom: test/run-geom-test src/vector_tile.pb.cc
 	./test/run-geom-test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-PROTOBUF_CXXFLAGS=$(shell pkg-config protobuf --cflags)
-PROTOBUF_LDFLAGS=$(shell pkg-config protobuf --libs-only-L) -lprotobuf-lite
 MAPNIK_CXXFLAGS=$(shell mapnik-config --cflags)
 MAPNIK_LDFLAGS=$(shell mapnik-config --libs --ldflags --dep-libs)
 COMMON_FLAGS = -Wall -pedantic -Wno-c++11-long-long -Wno-c++11-extensions -Wno-unknown-pragmas
@@ -18,7 +16,7 @@ src/vector_tile.pb.cc: proto/vector_tile.proto
 	protoc -Iproto/ --cpp_out=./src proto/vector_tile.proto
 
 test/run-test: Makefile src/vector_tile.pb.cc test/vector_tile.cpp test/test_utils.hpp src/*
-	$(CXX) -o ./test/run-test test/vector_tile.cpp src/vector_tile.pb.cc -I./src $(CXXFLAGS) $(MAPNIK_CXXFLAGS) $(PROTOBUF_CXXFLAGS) $(COMMON_FLAGS) $(MAPNIK_LDFLAGS) $(PROTOBUF_LDFLAGS) $(LDFLAGS) -Wno-unused-private-field
+	$(CXX) -o ./test/run-test test/vector_tile.cpp src/vector_tile.pb.cc -I./src $(CXXFLAGS) $(MAPNIK_CXXFLAGS) $(COMMON_FLAGS) $(MAPNIK_LDFLAGS) $(LDFLAGS) -Wno-unused-private-field
 
 test: test/run-test test/run-geom-test ./test/run-raster-test src/vector_tile.pb.cc test/catch.hpp
 	./test/run-test
@@ -26,11 +24,11 @@ test: test/run-test test/run-geom-test ./test/run-raster-test src/vector_tile.pb
 	./test/run-raster-test
 
 ./test/run-raster-test: Makefile src/vector_tile.pb.cc test/raster_tile.cpp test/encoding_util.hpp src/*
-	$(CXX) -o ./test/run-raster-test test/raster_tile.cpp src/vector_tile.pb.cc -DMAPNIK_PLUGINDIR=\"$(MAPNIK_PLUGINDIR)\" -I./src $(CXXFLAGS) $(MAPNIK_CXXFLAGS) $(PROTOBUF_CXXFLAGS) $(COMMON_FLAGS) $(MAPNIK_LDFLAGS) $(PROTOBUF_LDFLAGS) $(LDFLAGS) -Wno-unused-private-field
+	$(CXX) -o ./test/run-raster-test test/raster_tile.cpp src/vector_tile.pb.cc -DMAPNIK_PLUGINDIR=\"$(MAPNIK_PLUGINDIR)\" -I./src $(CXXFLAGS) $(MAPNIK_CXXFLAGS) $(COMMON_FLAGS) $(MAPNIK_LDFLAGS) $(LDFLAGS) -Wno-unused-private-field
 	./test/run-raster-test
 
 ./test/run-geom-test: Makefile src/vector_tile.pb.cc test/geometry_encoding.cpp test/encoding_util.hpp src/vector_tile_geometry_encoder.hpp src/*
-	@$(CXX) -o ./test/run-geom-test test/geometry_encoding.cpp src/vector_tile.pb.cc -I./src $(CXXFLAGS) $(MAPNIK_CXXFLAGS) $(PROTOBUF_CXXFLAGS) $(COMMON_FLAGS) $(MAPNIK_LDFLAGS) $(PROTOBUF_LDFLAGS) $(LDFLAGS) -Wno-unused-private-field
+	@$(CXX) -o ./test/run-geom-test test/geometry_encoding.cpp src/vector_tile.pb.cc -I./src $(CXXFLAGS) $(MAPNIK_CXXFLAGS) $(COMMON_FLAGS) $(MAPNIK_LDFLAGS) $(LDFLAGS) -Wno-unused-private-field
 
 geom: test/run-geom-test src/vector_tile.pb.cc
 	./test/run-geom-test

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,6 +25,22 @@ function install() {
 function install_mason_deps() {
     install mapnik dev
     install protobuf 2.6.1
+    install freetype 2.5.4
+    install harfbuzz 2cd5323
+    install jpeg_turbo 1.4.0
+    install libxml2 2.9.2
+    install libpng 1.6.16
+    install webp 0.4.2
+    install icu 54.1
+    install proj 4.8.0
+    install libtiff 4.0.4beta
+    install boost 1.57.0
+    install boost_libsystem 1.57.0
+    install boost_libthread 1.57.0
+    install boost_libfilesystem 1.57.0
+    install boost_libprogram_options 1.57.0
+    install boost_libregex 1.57.0
+    install boost_libpython 1.57.0
 }
 
 function setup_runtime_settings() {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+function setup_mason() {
+    if [[ ! -d ./.mason ]]; then
+        git clone --depth 1 https://github.com/mapbox/mason.git ./.mason
+    else
+        echo "Updating to latest mason"
+        (cd ./.mason && git pull)
+    fi
+    export MASON_DIR=$(pwd)/.mason
+    if [[ $(uname -s) == 'Linux' ]]; then source ./.mason/scripts/setup_cpp11_toolchain.sh; fi
+    export PATH=$(pwd)/.mason:$PATH
+    export CXX=${CXX:-clang++}
+    export CC=${CC:-clang}
+}
+
+function install() {
+    MASON_PLATFORM_ID=$(mason env MASON_PLATFORM_ID)
+    if [[ ! -d ./mason_packages/${MASON_PLATFORM_ID}/${1}/ ]]; then
+        mason install $1 $2
+        mason link $1 $2
+    fi
+}
+
+function install_mason_deps() {
+    install mapnik dev
+    install protobuf 2.6.1
+}
+
+function setup_runtime_settings() {
+    local MASON_LINKED_ABS=$(pwd)/mason_packages/.link
+    export PROJ_LIB=${MASON_LINKED_ABS}/share/proj
+    export ICU_DATA=${MASON_LINKED_ABS}/share/icu/54.1
+    export GDAL_DATA=${MASON_LINKED_ABS}/share/gdal
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        export DYLD_LIBRARY_PATH=$(pwd)/mason_packages/.link/lib:${DYLD_LIBRARY_PATH}
+    else
+        export LD_LIBRARY_PATH=$(pwd)/mason_packages/.link/lib:${LD_LIBRARY_PATH}
+    fi
+    export PATH=$(pwd)/mason_packages/.link/bin:${PATH}
+}
+
+function main() {
+    setup_mason
+    install_mason_deps
+    setup_runtime_settings
+    echo "Ready, now run:"
+    echo ""
+    echo "    make test"
+}
+
+main

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -41,6 +41,8 @@ function install_mason_deps() {
     install boost_libprogram_options 1.57.0
     install boost_libregex 1.57.0
     install boost_libpython 1.57.0
+    install pixman 0.32.6
+    install cairo 1.12.18
 }
 
 function setup_runtime_settings() {


### PR DESCRIPTION
This replaces the use of the Mapnik PPA (https://launchpad.net/~mapnik/+archive/ubuntu/nightly-trunk/+packages) for testing builds. It would be nice to keep testing against the PPA-built Mapnik, however:

 - PPA builds are currently broken due to https://github.com/mapnik/mapnik/issues/2677
 - PPA builds depend on older apt .deb's for gdal, cairo, etc so this make visual testing a pain (refs https://github.com/mapnik/mapnik/issues/2662)
 - PPA builds only happen once a night, which is not fast enough for easy iteration (the mason package will update whenever we push a commit to https://github.com/mapbox/mason/tree/mapnik-dev)

So, Mason-packaged mapnik is a better solution for travis testing. Getting the PPA-based approach working again is not something I am going to put effort into. So someone else would need to step up if testing against PPA builds of master is important to them. Note: we'll continue using the PPA to test the 0.6.x series of mapnik-vector-tile against Mapnik 2.x - refs https://github.com/mapbox/mapnik-vector-tile/issues/81