### PR TITLE
Better line clip

### DIFF
--- a/src/vector_tile_processor.ipp
+++ b/src/vector_tile_processor.ipp
@@ -48,6 +48,7 @@
 
 #include <boost/optional.hpp>
 #include <boost/geometry/algorithms/simplify.hpp>
+#include <boost/geometry/algorithms/intersection.hpp>
 
 #include <iostream>
 #include <string>
@@ -947,80 +948,63 @@ struct encoder_visitor {
     {
         unsigned path_count = 0;
         if (geom.size() < 2) return 0;
-        mapnik::geometry::line_string<std::int64_t> clip_box;
+        std::deque<mapnik::geometry::line_string<int64_t>> result;
+        mapnik::geometry::linear_ring<std::int64_t> clip_box;
         clip_box.emplace_back(buffered_query_ext_.minx(),buffered_query_ext_.miny());
         clip_box.emplace_back(buffered_query_ext_.maxx(),buffered_query_ext_.miny());
         clip_box.emplace_back(buffered_query_ext_.maxx(),buffered_query_ext_.maxy());
         clip_box.emplace_back(buffered_query_ext_.minx(),buffered_query_ext_.maxy());
         clip_box.emplace_back(buffered_query_ext_.minx(),buffered_query_ext_.miny());
-        ClipperLib::Clipper clipper;
-        //clipper.StrictlySimple(true);
-        if (!clipper.AddPath(geom, ClipperLib::ptSubject, false))
+        boost::geometry::intersection(clip_box,geom,result);
+        if (!result.empty())
         {
-            return 0;
+            backend_.start_tile_feature(feature_);
+            backend_.current_feature_->set_type(vector_tile::Tile_GeomType_LINESTRING);
+            for (auto const& ls : result)
+            {
+                path_count += backend_.add_path(ls);
+            }
+            backend_.stop_tile_feature();
         }
-        if (!clipper.AddPath( clip_box, ClipperLib::ptClip, true ))
-        {
-            return 0;
-        }
-        ClipperLib::PolyTree polylines;
-        mapnik::geometry::multi_line_string<std::int64_t> output_mls;
-        clipper.Execute(ClipperLib::ctIntersection, polylines); //, ClipperLib::pftNonZero);
-        ClipperLib::OpenPathsFromPolyTree(polylines, output_mls);
-        if (output_mls.empty())
-        {
-            return 0;
-        }
-        backend_.start_tile_feature(feature_);
-        backend_.current_feature_->set_type(vector_tile::Tile_GeomType_LINESTRING);
-        for (auto const& ls : output_mls)
-        {
-            path_count += backend_.add_path(ls);
-        }
-        backend_.stop_tile_feature();
         return path_count;
     }
 
     unsigned operator() (mapnik::geometry::multi_line_string<std::int64_t> & geom)
     {
         unsigned path_count = 0;
-        if (geom.empty()) return 0;
-        mapnik::geometry::line_string<std::int64_t> clip_box;
+        mapnik::geometry::linear_ring<std::int64_t> clip_box;
         clip_box.emplace_back(buffered_query_ext_.minx(),buffered_query_ext_.miny());
         clip_box.emplace_back(buffered_query_ext_.maxx(),buffered_query_ext_.miny());
         clip_box.emplace_back(buffered_query_ext_.maxx(),buffered_query_ext_.maxy());
         clip_box.emplace_back(buffered_query_ext_.minx(),buffered_query_ext_.maxy());
         clip_box.emplace_back(buffered_query_ext_.minx(),buffered_query_ext_.miny());
-        ClipperLib::Clipper clipper;
-        //clipper.StrictlySimple(true);
-        for (auto const& ls : geom)
+        bool first = true;
+        for (auto const& line : geom)
         {
-            if (ls.size() < 2) continue; 
-            if (!clipper.AddPath(ls, ClipperLib::ptSubject, false))
+            if (line.size() < 2)
             {
-                continue;
+               continue;
+            }
+            std::deque<mapnik::geometry::line_string<int64_t>> result;
+            boost::geometry::intersection(clip_box,line,result);
+            if (!result.empty())
+            {
+                if (first)
+                {
+                    first = false;
+                    backend_.start_tile_feature(feature_);
+                    backend_.current_feature_->set_type(vector_tile::Tile_GeomType_LINESTRING);
+                }
+                for (auto const& ls : result)
+                {
+                    path_count += backend_.add_path(ls);
+                }
             }
         }
-        if (!clipper.AddPath( clip_box, ClipperLib::ptClip, true ))
+        if (!first)
         {
-            return 0;
+            backend_.stop_tile_feature();
         }
-        ClipperLib::PolyTree polylines;
-        mapnik::geometry::multi_line_string<std::int64_t> output_mls;
-        clipper.Execute(ClipperLib::ctIntersection, polylines); //, ClipperLib::pftNonZero);
-        ClipperLib::OpenPathsFromPolyTree(polylines, output_mls);
-        clipper.Clear();
-        if (output_mls.empty())
-        {
-            return 0;
-        }
-        backend_.start_tile_feature(feature_);
-        backend_.current_feature_->set_type(vector_tile::Tile_GeomType_LINESTRING);
-        for (auto const& ls : output_mls)
-        {
-            path_count += backend_.add_path(ls);
-        }
-        backend_.stop_tile_feature();
         return path_count;
     }
 

--- a/test/vector_tile.cpp
+++ b/test/vector_tile.cpp
@@ -657,7 +657,7 @@ TEST_CASE( "vector tile multi_point encoding of actual multi_point", "should cre
     CHECK( !mapnik::geometry::is_empty(new_geom) );
     std::string wkt;
     CHECK( mapnik::util::to_wkt(wkt, new_geom) );
-    CHECK( wkt == "MULTIPOINT(128 -128,128.711 -126.578" );
+    CHECK( wkt == "MULTIPOINT(128 -128,128.711 -126.578)" );
     CHECK( new_geom.is<mapnik::geometry::multi_point<double> >() );
 }
 
@@ -698,6 +698,9 @@ TEST_CASE( "vector tile multi_line_string encoding of actual multi_line_string",
     line2.add_coord(-100,-100);
     geom.emplace_back(std::move(line2));
     mapnik::geometry::geometry<double> new_geom = round_trip(geom);
+    std::string wkt;
+    CHECK( mapnik::util::to_wkt(wkt, new_geom) );
+    CHECK( wkt == "MULTILINESTRING((128 -128,192.001 0),(120.889 -128,63.288 -256))" );
     CHECK( !mapnik::geometry::is_empty(new_geom) );
     CHECK( new_geom.is<mapnik::geometry::multi_line_string<double> >() );
 }
@@ -713,9 +716,9 @@ TEST_CASE( "vector tile polygon encoding", "should create vector tile with data"
     mapnik::geometry::geometry<double> new_geom = round_trip(geom);
     CHECK( !mapnik::geometry::is_empty(new_geom) );
     CHECK( new_geom.is<mapnik::geometry::polygon<double> >() );
-    std::string foo;
-    mapnik::util::to_wkt(foo, new_geom);
-    INFO(foo);
+    std::string wkt;
+    CHECK( mapnik::util::to_wkt(wkt, new_geom) );
+    CHECK( wkt == "POLYGON((128 -113.778,120.889 -113.778,120.889 -128,128 -128,128 -113.778))" );
 }
 
 
@@ -729,6 +732,9 @@ TEST_CASE( "vector tile multi_polygon encoding of single polygon", "should creat
     mapnik::geometry::multi_polygon<double> geom;
     geom.emplace_back(std::move(poly));
     mapnik::geometry::geometry<double> new_geom = round_trip(geom);
+    std::string wkt;
+    CHECK( mapnik::util::to_wkt(wkt, new_geom) );
+    CHECK( wkt == "POLYGON((128 -113.778,120.889 -113.778,120.889 -128,128 -128,128 -113.778))" );
     CHECK( !mapnik::geometry::is_empty(new_geom) );
     CHECK( new_geom.is<mapnik::geometry::polygon<double> >() );
 }
@@ -775,6 +781,9 @@ TEST_CASE( "vector tile multi_polygon encoding of actual multi_polygon", "should
 TEST_CASE( "vector tile point correctly passed through simplification code path", "should create vector tile with data" ) {
     mapnik::geometry::point<double> geom(-122,48);
     mapnik::geometry::geometry<double> new_geom = round_trip(geom,500);
+    std::string wkt;
+    CHECK( mapnik::util::to_wkt(wkt, new_geom) );
+    CHECK( wkt == "POINT(41.244 -59.733)" );
     CHECK( !mapnik::geometry::is_empty(new_geom) );
     CHECK( new_geom.is<mapnik::geometry::point<double> >() );
 }
@@ -788,6 +797,27 @@ TEST_CASE( "vector tile line_string is simplified", "should create vector tile w
     line.add_coord(100,100);
     geom.emplace_back(std::move(line));
     mapnik::geometry::geometry<double> new_geom = round_trip(geom,500);
+    std::string wkt;
+    CHECK( mapnik::util::to_wkt(wkt, new_geom) );
+    CHECK( wkt == "LINESTRING(128 -128,192.001 0)" );
+    CHECK( !mapnik::geometry::is_empty(new_geom) );
+    CHECK( new_geom.is<mapnik::geometry::line_string<double> >() );
+    auto const& line2 = mapnik::util::get<mapnik::geometry::line_string<double> >(new_geom);
+    CHECK( line2.size() == 2 );
+}
+
+TEST_CASE( "vector tile line_string is simplified when outside bounds", "should create vector tile with data" ) {
+    mapnik::geometry::multi_line_string<double> geom;
+    mapnik::geometry::line_string<double> line;
+    line.add_coord(-10000,0);
+    line.add_coord(-10000.1,0);
+    line.add_coord(100000,0);
+    geom.emplace_back(std::move(line));
+    mapnik::geometry::geometry<double> new_geom = round_trip(geom,100);
+    std::string wkt;
+    CHECK( mapnik::util::to_wkt(wkt, new_geom) );
+    // yep this test is weird - more of a fuzz than anything
+    CHECK( wkt == "LINESTRING(-7369.526 -128,-7113.526 -128)" );
     CHECK( !mapnik::geometry::is_empty(new_geom) );
     CHECK( new_geom.is<mapnik::geometry::line_string<double> >() );
     auto const& line2 = mapnik::util::get<mapnik::geometry::line_string<double> >(new_geom);


### PR DESCRIPTION
Moves to `boost::geometry::intersection` instead of Clipper: the advantage is that `boost::geometry::intersection` preserves orientation whereas Clipper does not.

BTW, using closed `linear_ring` for the clipping box instead of a true `box` due to this bug: https://github.com/springmeyer/boost-geometry-line-clipping-testcase