### PR TITLE
Optimize coordinate transformations

### DIFF
--- a/bench/vtile-transform.cpp
+++ b/bench/vtile-transform.cpp
@@ -46,8 +46,9 @@ int main() {
 
     unsigned count = 0;
     unsigned count2 = 0;
+    unsigned count3 = 0;
     {
-        mapnik::vector_tile_impl::vector_tile_strategy vs(prj_trans, tr, 16);
+        mapnik::vector_tile_impl::vector_tile_strategy vs(tr, 16);
         mapnik::progress_timer __stats__(std::clog, "boost::geometry::transform");
         for (unsigned i=0;i<10000;++i)
         {
@@ -57,9 +58,9 @@ int main() {
         }
     }
     {
-        mapnik::vector_tile_impl::vector_tile_strategy vs(prj_trans, tr, 16);
-        mapnik::progress_timer __stats__(std::clog, "transform_visitor with reserve");
-        mapnik::vector_tile_impl::transform_visitor transit(vs);
+        mapnik::vector_tile_impl::vector_tile_strategy_proj vs(prj_trans,tr, 16);
+        mapnik::progress_timer __stats__(std::clog, "transform_visitor with reserve with proj no-op");
+        mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy_proj> transit(vs);
         for (unsigned i=0;i<10000;++i)
         {
             mapnik::geometry::geometry<std::int64_t> new_geom = mapnik::util::apply_visitor(transit,geom);        
@@ -67,6 +68,22 @@ int main() {
             count2 += poly.size();
         }
         if (count != count2)
+        {
+            std::clog << "tests did not run as expected!\n";
+            return -1;
+        }
+    }
+    {
+        mapnik::vector_tile_impl::vector_tile_strategy vs(tr, 16);
+        mapnik::progress_timer __stats__(std::clog, "transform_visitor with reserve with no proj function call overhead");
+        mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy> transit(vs);
+        for (unsigned i=0;i<10000;++i)
+        {
+            mapnik::geometry::geometry<std::int64_t> new_geom = mapnik::util::apply_visitor(transit,geom);
+            auto const& poly = mapnik::util::get<mapnik::geometry::multi_polygon<std::int64_t>>(new_geom);
+            count3 += poly.size();
+        }
+        if (count != count3)
         {
             std::clog << "tests did not run as expected!\n";
             return -1;

--- a/src/vector_tile_processor.hpp
+++ b/src/vector_tile_processor.hpp
@@ -63,6 +63,11 @@ public:
         return simplify_distance_;
     }
 
+    inline mapnik::view_transform const& get_transform()
+    {
+        return t_;
+    }
+
     MAPNIK_VECTOR_INLINE void apply(double scale_denom=0.0);
 
     MAPNIK_VECTOR_INLINE bool painted() const;
@@ -76,9 +81,10 @@ public:
                         box2d<double> const& extent,
                         int buffer_size);
 
-    MAPNIK_VECTOR_INLINE unsigned handle_geometry(mapnik::feature_impl const& feature,
+    template <typename T2>
+    MAPNIK_VECTOR_INLINE unsigned handle_geometry(T2 const& vs,
+                                                  mapnik::feature_impl const& feature,
                                                   mapnik::geometry::geometry<double> const& geom,
-                                                  mapnik::proj_transform const& prj_trans,
                                                   mapnik::box2d<double> const& buffered_query_ext);
 };
 

--- a/test/clipper_test.cpp
+++ b/test/clipper_test.cpp
@@ -21,7 +21,7 @@ TEST_CASE( "vector_tile_strategy", "should not overflow" ) {
     mapnik::box2d<double> z15_extent(minx,miny,maxx,maxy);
     mapnik::view_transform tr(tile_size,tile_size,z15_extent,0,0);
     {
-        mapnik::vector_tile_impl::vector_tile_strategy vs(prj_trans, tr, 16);
+        mapnik::vector_tile_impl::vector_tile_strategy_proj vs(prj_trans, tr, 16);
         // even an invalid point is not expected to result in values beyond hirange
         mapnik::geometry::point<double> g(-20037508.342789*2.0,-20037508.342789*2.0);
         mapnik::geometry::geometry<std::int64_t> new_geom = mapnik::geometry::transform<std::int64_t>(g, vs);
@@ -42,7 +42,7 @@ TEST_CASE( "vector_tile_strategy", "should not overflow" ) {
     {
         // absurdly large but still should not result in values beyond hirange
         double path_multiplier = 100000000000.0;
-        mapnik::vector_tile_impl::vector_tile_strategy vs(prj_trans, tr, path_multiplier);
+        mapnik::vector_tile_impl::vector_tile_strategy_proj vs(prj_trans, tr, path_multiplier);
         mapnik::geometry::geometry<std::int64_t> new_geom = mapnik::geometry::transform<std::int64_t>(g, vs);
         REQUIRE( new_geom.is<mapnik::geometry::polygon<std::int64_t>>() );
         auto const& poly = mapnik::util::get<mapnik::geometry::polygon<std::int64_t>>(new_geom);
@@ -59,9 +59,9 @@ TEST_CASE( "vector_tile_strategy", "should not overflow" ) {
     {
         // expected to trigger values above hirange
         double path_multiplier = 1000000000000.0;
-        mapnik::vector_tile_impl::vector_tile_strategy vs(prj_trans, tr, path_multiplier);
+        mapnik::vector_tile_impl::vector_tile_strategy_proj vs(prj_trans, tr, path_multiplier);
         CHECK_THROWS( mapnik::geometry::transform<std::int64_t>(g, vs) );
-        mapnik::vector_tile_impl::transform_visitor skipping_transformer(vs);
+        mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy_proj> skipping_transformer(vs);
         mapnik::geometry::geometry<std::int64_t> new_geom = skipping_transformer(g);
         REQUIRE( new_geom.is<mapnik::geometry::polygon<std::int64_t>>() );
         auto const& poly = mapnik::util::get<mapnik::geometry::polygon<std::int64_t>>(new_geom);
@@ -87,9 +87,9 @@ TEST_CASE( "vector_tile_strategy2", "invalid mercator coord in interior ring" ) 
     merc_tiler.xyz(9664,20435,15,minx,miny,maxx,maxy);
     mapnik::box2d<double> z15_extent(minx,miny,maxx,maxy);
     mapnik::view_transform tr(tile_size,tile_size,z15_extent,0,0);
-    mapnik::vector_tile_impl::vector_tile_strategy vs(prj_trans, tr, 16);
+    mapnik::vector_tile_impl::vector_tile_strategy_proj vs(prj_trans, tr, 16);
     CHECK_THROWS( mapnik::geometry::transform<std::int64_t>(geom, vs) );
-    mapnik::vector_tile_impl::transform_visitor skipping_transformer(vs);
+    mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy_proj> skipping_transformer(vs);
     mapnik::geometry::geometry<std::int64_t> new_geom = mapnik::util::apply_visitor(skipping_transformer,geom);
     REQUIRE( new_geom.is<mapnik::geometry::polygon<std::int64_t>>() );
     auto const& poly = mapnik::util::get<mapnik::geometry::polygon<std::int64_t>>(new_geom);

--- a/test/vector_tile.cpp
+++ b/test/vector_tile.cpp
@@ -956,7 +956,7 @@ TEST_CASE( "vector tile from simplified geojson", "should create vector tile wit
     REQUIRE(1 == tile.layers_size());
     vector_tile::Tile_Layer const& layer = tile.layers(0);
     CHECK(std::string("layer") == layer.name());
-    CHECK(1 == layer.features_size());
+    REQUIRE(1 == layer.features_size());
     vector_tile::Tile_Feature const& f = layer.features(0);
     unsigned z = 0;
     unsigned x = 0;

--- a/test/vector_tile.cpp
+++ b/test/vector_tile.cpp
@@ -26,6 +26,7 @@
 // vector output api
 #include "vector_tile_compression.hpp"
 #include "vector_tile_processor.hpp"
+#include "vector_tile_strategy.hpp"
 #include "vector_tile_backend_pbf.hpp"
 #include "vector_tile_util.hpp"
 #include "vector_tile_projection.hpp"
@@ -606,7 +607,8 @@ mapnik::geometry::geometry<double> round_trip(mapnik::geometry::geometry<double>
     mapnik::projection merc("+init=epsg:4326",true);
     mapnik::proj_transform prj_trans(merc,wgs84);
     ren.set_simplify_distance(simplify_distance);
-    ren.handle_geometry(*feature,geom,prj_trans,bbox);
+    mapnik::vector_tile_impl::vector_tile_strategy_proj vs(prj_trans,ren.get_transform(),backend.get_path_multiplier());
+    ren.handle_geometry(vs,*feature,geom,bbox);
     backend.stop_tile_layer();
     if (tile.layers_size() != 1)
     {
@@ -1006,7 +1008,8 @@ mapnik::geometry::geometry<double> round_trip2(mapnik::geometry::geometry<double
     {
         throw std::runtime_error("simplify_distance setter did not work");
     }
-    ren.handle_geometry(*feature,geom,prj_trans,bbox);
+    mapnik::vector_tile_impl::vector_tile_strategy_proj vs(prj_trans,ren.get_transform(),backend.get_path_multiplier());
+    ren.handle_geometry(vs,*feature,geom,bbox);
     backend.stop_tile_layer();
     if (tile.layers_size() != 1)
     {

--- a/test/vector_tile_pbf.cpp
+++ b/test/vector_tile_pbf.cpp
@@ -144,10 +144,10 @@ TEST_CASE( "pbf vector tile datasource", "should filter features outside extent"
     std::string key("");
     CHECK(false == mapnik::vector_tile_impl::is_solid_extent(tile,key));
     CHECK("" == key);
-    CHECK(1 == tile.layers_size());
+    REQUIRE(1 == tile.layers_size());
     vector_tile::Tile_Layer const& layer = tile.layers(0);
     CHECK(std::string("layer") == layer.name());
-    CHECK(1 == layer.features_size());
+    REQUIRE(1 == layer.features_size());
     vector_tile::Tile_Feature const& f = layer.features(0);
     CHECK(static_cast<mapnik::value_integer>(1) == static_cast<mapnik::value_integer>(f.id()));
     CHECK(3 == f.geometry_size());
@@ -261,9 +261,9 @@ TEST_CASE( "pbf encoding multi line as one path", "should maintain second move_t
     std::string key("");
     CHECK(false == mapnik::vector_tile_impl::is_solid_extent(tile,key));
     CHECK("" == key);
-    CHECK(1 == tile.layers_size());
+    REQUIRE(1 == tile.layers_size());
     vector_tile::Tile_Layer const& layer = tile.layers(0);
-    CHECK(1 == layer.features_size());
+    REQUIRE(1 == layer.features_size());
     vector_tile::Tile_Feature const& f = layer.features(0);
     CHECK(12 == f.geometry_size());
     CHECK(9 == f.geometry(0)); // 1 move_to
@@ -343,10 +343,10 @@ TEST_CASE( "pbf decoding some truncated buffers", "should throw exception" ) {
     std::string key("");
     CHECK(false == mapnik::vector_tile_impl::is_solid_extent(tile,key));
     CHECK("" == key);
-    CHECK(1 == tile.layers_size());
+    REQUIRE(1 == tile.layers_size());
     vector_tile::Tile_Layer const& layer = tile.layers(0);
     CHECK(std::string("layer") == layer.name());
-    CHECK(1 == layer.features_size());
+    REQUIRE(1 == layer.features_size());
     vector_tile::Tile_Feature const& f = layer.features(0);
     CHECK(static_cast<mapnik::value_integer>(1) == static_cast<mapnik::value_integer>(f.id()));
     CHECK(3 == f.geometry_size());
@@ -397,10 +397,10 @@ TEST_CASE( "pbf vector tile from simplified geojson", "should create vector tile
     renderer_type ren(backend,map,m_req);
     ren.apply();
     CHECK( ren.painted() == true );
-    CHECK(1 == tile.layers_size());
+    REQUIRE(1 == tile.layers_size());
     vector_tile::Tile_Layer const& layer = tile.layers(0);
     CHECK(std::string("layer") == layer.name());
-    CHECK(1 == layer.features_size());
+    REQUIRE(1 == layer.features_size());
     vector_tile::Tile_Feature const& f = layer.features(0);
     unsigned z = 0;
     unsigned x = 0;
@@ -478,10 +478,10 @@ TEST_CASE( "pbf raster tile output", "should be able to overzoom raster" ) {
         ren.apply();
     }
     // Done creating test data, now test created tile
-    CHECK(1 == tile.layers_size());
+    REQUIRE(1 == tile.layers_size());
     vector_tile::Tile_Layer const& layer = tile.layers(0);
     CHECK(std::string("layer") == layer.name());
-    CHECK(1 == layer.features_size());
+    REQUIRE(1 == layer.features_size());
     vector_tile::Tile_Feature const& f = layer.features(0);
     CHECK(static_cast<mapnik::value_integer>(1) == static_cast<mapnik::value_integer>(f.id()));
     CHECK(0 == f.geometry_size());


### PR DESCRIPTION
In https://github.com/mapbox/mapnik-vector-tile/commit/9dd27291ee7d84507a1b466d3d45a7aa84185791#diff-2aabba777685cca077a1c8766e95e711R39 I optimized the `vector_tile_strategy` significantly to avoid the overhead of the function call to `prj_trans.backward` even when it is a no-op at https://github.com/mapnik/mapnik/blob/b285bde44bb009d5c619d393bb4902cf96bd98d1/src/proj_transform.cpp#L187-L188. I think this was a lot faster because of the excessive amount of non-inlinable function overloads in https://github.com/mapnik/mapnik/blob/b285bde44bb009d5c619d393bb4902cf96bd98d1/include/mapnik/proj_transform.hpp#L47-L58.

This commit optimized further by avoiding the `prj_trans.equal()` call per feature. This speeds up the benchmark noticeably:

```
2249.26ms (cpu 2227.56ms)   | boost::geometry::transform
1935.95ms (cpu 1807.54ms)   | transform_visitor with reserve with proj no-op
1775.08ms (cpu 1699.88ms)   | transform_visitor with reserve with no proj function call overhead
```

