### PR TITLE
Aggressively filter out geometries outside (buffered) tile extents

### DIFF
--- a/bench/vtile-transform.cpp
+++ b/bench/vtile-transform.cpp
@@ -60,10 +60,10 @@ int main() {
     {
         mapnik::vector_tile_impl::vector_tile_strategy_proj vs(prj_trans,tr, 16);
         mapnik::progress_timer __stats__(std::clog, "transform_visitor with reserve with proj no-op");
-        mapnik::box2d<int> clip_extent(std::numeric_limits<int>::min(),
-                                       std::numeric_limits<int>::min(),
-                                       std::numeric_limits<int>::max(),
-                                       std::numeric_limits<int>::max());
+        mapnik::box2d<double> clip_extent(std::numeric_limits<double>::min(),
+                                       std::numeric_limits<double>::min(),
+                                       std::numeric_limits<double>::max(),
+                                       std::numeric_limits<double>::max());
         mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy_proj> transit(vs, clip_extent);
         for (unsigned i=0;i<10000;++i)
         {
@@ -80,10 +80,10 @@ int main() {
     {
         mapnik::vector_tile_impl::vector_tile_strategy vs(tr, 16);
         mapnik::progress_timer __stats__(std::clog, "transform_visitor with reserve with no proj function call overhead");
-        mapnik::box2d<int> clip_extent(std::numeric_limits<int>::min(),
-                                       std::numeric_limits<int>::min(),
-                                       std::numeric_limits<int>::max(),
-                                       std::numeric_limits<int>::max());
+        mapnik::box2d<double> clip_extent(std::numeric_limits<double>::min(),
+                                       std::numeric_limits<double>::min(),
+                                       std::numeric_limits<double>::max(),
+                                       std::numeric_limits<double>::max());
         mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy> transit(vs, clip_extent);
         for (unsigned i=0;i<10000;++i)
         {

--- a/bench/vtile-transform.cpp
+++ b/bench/vtile-transform.cpp
@@ -60,7 +60,11 @@ int main() {
     {
         mapnik::vector_tile_impl::vector_tile_strategy_proj vs(prj_trans,tr, 16);
         mapnik::progress_timer __stats__(std::clog, "transform_visitor with reserve with proj no-op");
-        mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy_proj> transit(vs);
+        mapnik::box2d<int> clip_extent(std::numeric_limits<int>::min(),
+                                       std::numeric_limits<int>::min(),
+                                       std::numeric_limits<int>::max(),
+                                       std::numeric_limits<int>::max());
+        mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy_proj> transit(vs, clip_extent);
         for (unsigned i=0;i<10000;++i)
         {
             mapnik::geometry::geometry<std::int64_t> new_geom = mapnik::util::apply_visitor(transit,geom);        
@@ -76,7 +80,11 @@ int main() {
     {
         mapnik::vector_tile_impl::vector_tile_strategy vs(tr, 16);
         mapnik::progress_timer __stats__(std::clog, "transform_visitor with reserve with no proj function call overhead");
-        mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy> transit(vs);
+        mapnik::box2d<int> clip_extent(std::numeric_limits<int>::min(),
+                                       std::numeric_limits<int>::min(),
+                                       std::numeric_limits<int>::max(),
+                                       std::numeric_limits<int>::max());
+        mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy> transit(vs, clip_extent);
         for (unsigned i=0;i<10000;++i)
         {
             mapnik::geometry::geometry<std::int64_t> new_geom = mapnik::util::apply_visitor(transit,geom);

--- a/src/vector_tile_processor.hpp
+++ b/src/vector_tile_processor.hpp
@@ -85,7 +85,8 @@ public:
     MAPNIK_VECTOR_INLINE unsigned handle_geometry(T2 const& vs,
                                                   mapnik::feature_impl const& feature,
                                                   mapnik::geometry::geometry<double> const& geom,
-                                                  mapnik::box2d<int> const& tile_clipping_extent);
+                                                  mapnik::box2d<int> const& tile_clipping_extent,
+                                                  mapnik::box2d<double> const& target_clipping_extent);
 };
 
 }} // end ns

--- a/src/vector_tile_processor.ipp
+++ b/src/vector_tile_processor.ipp
@@ -912,13 +912,10 @@ struct encoder_visitor {
     unsigned operator() (mapnik::geometry::point<std::int64_t> const& geom)
     {
         unsigned path_count = 0;
-        if (tile_clipping_extent_.intersects(geom.x,geom.y))
-        {
-            backend_.start_tile_feature(feature_);
-            backend_.current_feature_->set_type(vector_tile::Tile_GeomType_POINT);
-            path_count = backend_.add_path(geom);
-            backend_.stop_tile_feature();
-        }
+        backend_.start_tile_feature(feature_);
+        backend_.current_feature_->set_type(vector_tile::Tile_GeomType_POINT);
+        path_count = backend_.add_path(geom);
+        backend_.stop_tile_feature();
         return path_count;
     }
 
@@ -928,16 +925,13 @@ struct encoder_visitor {
         bool first = true;
         for (auto const& pt : geom)
         {
-            if (tile_clipping_extent_.intersects(pt.x,pt.y))
+            if (first)
             {
-                if (first)
-                {
-                    first = false;
-                    backend_.start_tile_feature(feature_);
-                    backend_.current_feature_->set_type(vector_tile::Tile_GeomType_POINT);
-                }
-                path_count += backend_.add_path(pt);
+                first = false;
+                backend_.start_tile_feature(feature_);
+                backend_.current_feature_->set_type(vector_tile::Tile_GeomType_POINT);
             }
+            path_count += backend_.add_path(pt);
         }
         if (!first)
         {

--- a/src/vector_tile_processor.ipp
+++ b/src/vector_tile_processor.ipp
@@ -24,7 +24,6 @@
 #include <mapnik/util/noncopyable.hpp>
 #include <mapnik/transform_path_adapter.hpp>
 #include <mapnik/geometry_is_empty.hpp>
-#include <mapnik/geometry_envelope.hpp>
 #include <mapnik/geometry_adapters.hpp>
 #include <mapnik/geometry_transform.hpp>
 
@@ -802,7 +801,8 @@ void processor<T>::apply_to_layer(mapnik::layer const& lay,
                 if (handle_geometry(vs,
                                     *feature,
                                     geom,
-                                    tile_clipping_extent) > 0)
+                                    tile_clipping_extent,
+                                    target_clipping_extent) > 0)
                 {
                     painted_ = true;
                 }
@@ -818,6 +818,7 @@ void processor<T>::apply_to_layer(mapnik::layer const& lay,
             mapnik::geometry::point<std::int64_t> p2_max = mapnik::geometry::transform<std::int64_t>(p1_max, vs);
             box2d<int> tile_clipping_extent(p2_min.x, p2_min.y, p2_max.x, p2_max.y);
             mapnik::vector_tile_impl::vector_tile_strategy_proj vs2(prj_trans,t_,backend_.get_path_multiplier());
+            prj_trans.forward(target_clipping_extent, PROJ_ENVELOPE_POINTS);
             while (feature)
             {
                 mapnik::geometry::geometry<double> const& geom = feature->get_geometry();
@@ -829,7 +830,8 @@ void processor<T>::apply_to_layer(mapnik::layer const& lay,
                 if (handle_geometry(vs2,
                                     *feature,
                                     geom,
-                                    tile_clipping_extent) > 0)
+                                    tile_clipping_extent,
+                                    target_clipping_extent) > 0)
                 {
                     painted_ = true;
                 }
@@ -1263,13 +1265,14 @@ template <typename T> template <typename T2>
 unsigned processor<T>::handle_geometry(T2 const& vs,
                                        mapnik::feature_impl const& feature,
                                        mapnik::geometry::geometry<double> const& geom,
-                                       mapnik::box2d<int> const& tile_clipping_extent)
+                                       mapnik::box2d<int> const& tile_clipping_extent,
+                                       mapnik::box2d<double> const& target_clipping_extent)
 {
     // TODO
     // - no need to create a new skipping_transformer per geometry
     // - write a non-skipping / zero copy transformer to be used when no projection is needed
     using vector_tile_strategy_type = T2;
-    mapnik::vector_tile_impl::transform_visitor<vector_tile_strategy_type> skipping_transformer(vs, tile_clipping_extent);
+    mapnik::vector_tile_impl::transform_visitor<vector_tile_strategy_type> skipping_transformer(vs, target_clipping_extent);
     mapnik::geometry::geometry<std::int64_t> new_geom = mapnik::util::apply_visitor(skipping_transformer,geom);
     encoder_visitor<T> encoder(backend_, feature, tile_clipping_extent, area_threshold_);
     if (simplify_distance_ > 0)

--- a/src/vector_tile_processor.ipp
+++ b/src/vector_tile_processor.ipp
@@ -1275,7 +1275,7 @@ unsigned processor<T>::handle_geometry(T2 const& vs,
     // - no need to create a new skipping_transformer per geometry
     // - write a non-skipping / zero copy transformer to be used when no projection is needed
     using vector_tile_strategy_type = T2;
-    mapnik::vector_tile_impl::transform_visitor<vector_tile_strategy_type> skipping_transformer(vs);
+    mapnik::vector_tile_impl::transform_visitor<vector_tile_strategy_type> skipping_transformer(vs, tile_clipping_extent);
     mapnik::geometry::geometry<std::int64_t> new_geom = mapnik::util::apply_visitor(skipping_transformer,geom);
     encoder_visitor<T> encoder(backend_, feature, tile_clipping_extent, area_threshold_);
     if (simplify_distance_ > 0)

--- a/src/vector_tile_strategy.hpp
+++ b/src/vector_tile_strategy.hpp
@@ -131,7 +131,6 @@ struct transform_visitor {
             }
         }
         if (new_geom.empty()) return mapnik::geometry::geometry_empty();
-        new_geom.shrink_to_fit();
         return new_geom;
     }
 
@@ -176,7 +175,6 @@ struct transform_visitor {
             new_geom.push_back(std::move(new_line));
         }
         if (new_geom.empty()) return mapnik::geometry::geometry_empty();
-        new_geom.shrink_to_fit();
         return new_geom;
     }
 
@@ -262,7 +260,6 @@ struct transform_visitor {
             new_geom.push_back(std::move(new_poly));
         }
         if (new_geom.empty()) return mapnik::geometry::geometry_empty();
-        new_geom.shrink_to_fit();
         return new_geom;
     }
 

--- a/test/clipper_test.cpp
+++ b/test/clipper_test.cpp
@@ -61,7 +61,11 @@ TEST_CASE( "vector_tile_strategy", "should not overflow" ) {
         double path_multiplier = 1000000000000.0;
         mapnik::vector_tile_impl::vector_tile_strategy_proj vs(prj_trans, tr, path_multiplier);
         CHECK_THROWS( mapnik::geometry::transform<std::int64_t>(g, vs) );
-        mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy_proj> skipping_transformer(vs);
+        mapnik::box2d<int> clip_extent(std::numeric_limits<int>::min(),
+                                       std::numeric_limits<int>::min(),
+                                       std::numeric_limits<int>::max(),
+                                       std::numeric_limits<int>::max());
+        mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy_proj> skipping_transformer(vs, clip_extent);
         mapnik::geometry::geometry<std::int64_t> new_geom = skipping_transformer(g);
         REQUIRE( new_geom.is<mapnik::geometry::polygon<std::int64_t>>() );
         auto const& poly = mapnik::util::get<mapnik::geometry::polygon<std::int64_t>>(new_geom);
@@ -89,7 +93,11 @@ TEST_CASE( "vector_tile_strategy2", "invalid mercator coord in interior ring" ) 
     mapnik::view_transform tr(tile_size,tile_size,z15_extent,0,0);
     mapnik::vector_tile_impl::vector_tile_strategy_proj vs(prj_trans, tr, 16);
     CHECK_THROWS( mapnik::geometry::transform<std::int64_t>(geom, vs) );
-    mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy_proj> skipping_transformer(vs);
+    mapnik::box2d<int> clip_extent(std::numeric_limits<int>::min(),
+                                   std::numeric_limits<int>::min(),
+                                   std::numeric_limits<int>::max(),
+                                   std::numeric_limits<int>::max());
+    mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy_proj> skipping_transformer(vs, clip_extent);
     mapnik::geometry::geometry<std::int64_t> new_geom = mapnik::util::apply_visitor(skipping_transformer,geom);
     REQUIRE( new_geom.is<mapnik::geometry::polygon<std::int64_t>>() );
     auto const& poly = mapnik::util::get<mapnik::geometry::polygon<std::int64_t>>(new_geom);

--- a/test/clipper_test.cpp
+++ b/test/clipper_test.cpp
@@ -61,10 +61,10 @@ TEST_CASE( "vector_tile_strategy", "should not overflow" ) {
         double path_multiplier = 1000000000000.0;
         mapnik::vector_tile_impl::vector_tile_strategy_proj vs(prj_trans, tr, path_multiplier);
         CHECK_THROWS( mapnik::geometry::transform<std::int64_t>(g, vs) );
-        mapnik::box2d<int> clip_extent(std::numeric_limits<int>::min(),
-                                       std::numeric_limits<int>::min(),
-                                       std::numeric_limits<int>::max(),
-                                       std::numeric_limits<int>::max());
+        mapnik::box2d<double> clip_extent(std::numeric_limits<double>::min(),
+                                       std::numeric_limits<double>::min(),
+                                       std::numeric_limits<double>::max(),
+                                       std::numeric_limits<double>::max());
         mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy_proj> skipping_transformer(vs, clip_extent);
         mapnik::geometry::geometry<std::int64_t> new_geom = skipping_transformer(g);
         REQUIRE( new_geom.is<mapnik::geometry::polygon<std::int64_t>>() );
@@ -93,10 +93,10 @@ TEST_CASE( "vector_tile_strategy2", "invalid mercator coord in interior ring" ) 
     mapnik::view_transform tr(tile_size,tile_size,z15_extent,0,0);
     mapnik::vector_tile_impl::vector_tile_strategy_proj vs(prj_trans, tr, 16);
     CHECK_THROWS( mapnik::geometry::transform<std::int64_t>(geom, vs) );
-    mapnik::box2d<int> clip_extent(std::numeric_limits<int>::min(),
-                                   std::numeric_limits<int>::min(),
-                                   std::numeric_limits<int>::max(),
-                                   std::numeric_limits<int>::max());
+    mapnik::box2d<double> clip_extent(std::numeric_limits<double>::min(),
+                                   std::numeric_limits<double>::min(),
+                                   std::numeric_limits<double>::max(),
+                                   std::numeric_limits<double>::max());
     mapnik::vector_tile_impl::transform_visitor<mapnik::vector_tile_impl::vector_tile_strategy_proj> skipping_transformer(vs, clip_extent);
     mapnik::geometry::geometry<std::int64_t> new_geom = mapnik::util::apply_visitor(skipping_transformer,geom);
     REQUIRE( new_geom.is<mapnik::geometry::polygon<std::int64_t>>() );

--- a/test/vector_tile.cpp
+++ b/test/vector_tile.cpp
@@ -614,7 +614,7 @@ mapnik::geometry::geometry<double> round_trip(mapnik::geometry::geometry<double>
     mapnik::geometry::point<std::int64_t> p2_min = mapnik::geometry::transform<std::int64_t>(p1_min, vs);
     mapnik::geometry::point<std::int64_t> p2_max = mapnik::geometry::transform<std::int64_t>(p1_max, vs);
     mapnik::box2d<int> clipping_extent(p2_min.x, p2_min.y, p2_max.x, p2_max.y);
-    ren.handle_geometry(vs2,*feature,geom,clipping_extent);
+    ren.handle_geometry(vs2,*feature,geom,clipping_extent, bbox);
     backend.stop_tile_layer();
     if (tile.layers_size() != 1)
     {
@@ -1021,7 +1021,7 @@ mapnik::geometry::geometry<double> round_trip2(mapnik::geometry::geometry<double
     mapnik::geometry::point<std::int64_t> p2_min = mapnik::geometry::transform<std::int64_t>(p1_min, vs);
     mapnik::geometry::point<std::int64_t> p2_max = mapnik::geometry::transform<std::int64_t>(p1_max, vs);
     mapnik::box2d<int> clipping_extent(p2_min.x, p2_min.y, p2_max.x, p2_max.y);
-    ren.handle_geometry(vs2,*feature,geom,clipping_extent);
+    ren.handle_geometry(vs2,*feature,geom,clipping_extent, bbox);
     backend.stop_tile_layer();
     if (tile.layers_size() != 1)
     {


### PR DESCRIPTION
This is a change to resolve #134