### PR TITLE
Make tileinfo example buildable

### DIFF
--- a/examples/c++/Makefile
+++ b/examples/c++/Makefile
@@ -5,8 +5,8 @@ LDFLAGS := $(LDFLAGS) # inherit from env
 
 all: tileinfo
 
-tileinfo: tileinfo.cpp ../../src/vector_tile.pb.cc
-	$(CXX) $(CXXFLAGS) $(PROTOBUF_CXXFLAGS) $(LDFLAGS) $(PROTOBUF_LDFLAGS) tileinfo.cpp ../../src/vector_tile.pb.cc -o tileinfo -lprotobuf-lite -lz
+tileinfo: tileinfo.cpp ../../build/Release/obj/gen/vector_tile.pb.cc
+	$(CXX) $(CXXFLAGS) $(PROTOBUF_CXXFLAGS) $(LDFLAGS) $(PROTOBUF_LDFLAGS) tileinfo.cpp ../../build/Release/obj/gen/vector_tile.pb.cc -o tileinfo -lprotobuf-lite -lz
 
 install: tileinfo
 	mkdir -p /usr/local/bin

--- a/examples/c++/tileinfo.cpp
+++ b/examples/c++/tileinfo.cpp
@@ -1,5 +1,5 @@
-#include "vector_tile.pb.h"
-#include "vector_tile_compression.hpp"
+#include "../../build/Release/obj/gen/vector_tile.pb.h"
+#include "../../src/vector_tile_compression.hpp"
 #include <vector>
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
The c++/tileinfo example can't be built. This makes it buildable again.