### PR TITLE
Filter geometries by bbox during decoding

### DIFF
--- a/bench/notes.md
+++ b/bench/notes.md
@@ -1,7 +1,7 @@
 With reserve
 
 ```
-$ ./build/Release/multi-point-decode bench/multi_line_13_1310_3166.vector.pbf 13 1310 3166
+$ ./build/Release/vtile-decode bench/multi_line_13_1310_3166.vector.pbf 13 1310 3166
 z:13 x:1310 y:3166 iterations:100
 message: zlib compressed
 4026.30ms (cpu 4020.96ms)   | decode as datasource_pbf: bench/multi_line_13_1310_3166.vector.pbf
@@ -10,10 +10,49 @@ message: zlib compressed
 without reserve code
 
 ```
-$ ./build/Release/multi-point-decode bench/multi_line_13_1310_3166.vector.pbf 13 1310 3166
+$ ./build/Release/vtile-decode bench/multi_line_13_1310_3166.vector.pbf 13 1310 3166
 z:13 x:1310 y:3166 iterations:100
 message: zlib compressed
 4296.88ms (cpu 4289.05ms)   | decode as datasource_pbf: bench/multi_line_13_1310_3166.vector.pbf
 ```
 
 
+---------
+
+
+baseline (using mapnik::geometry::envelope + filter.pass)
+
+$ .//build/Release/vtile-decode bench/enf.t5yd5cdi_14_13089_8506.vector.pbf 14 13089 8506 200
+z:14 x:13089 y:8506 iterations:200
+2822.66ms (cpu 2821.10ms)   | decode as datasource_pbf: bench/enf.t5yd5cdi_14_13089_8506.vector.pbf
+2070.90ms (cpu 2070.44ms)   | decode as datasource: bench/enf.t5yd5cdi_14_13089_8506.vector.pbf
+processed 6800 features
+
+$ ./build/Release/vtile-decode bench/multi_line_13_1310_3166.vector.pbf 13 1310 3166 100
+z:13 x:1310 y:3166 iterations:100
+message: zlib compressed
+4289.26ms (cpu 4275.29ms)   | decode as datasource_pbf: bench/multi_line_13_1310_3166.vector.pbf
+
+
+
+commenting filter.pass/geometry::envelope in datasource_pbf
+
+$ .//build/Release/vtile-decode bench/enf.t5yd5cdi_14_13089_8506.vector.pbf 14 13089 8506 200
+z:14 x:13089 y:8506 iterations:200
+2305.45ms (cpu 2301.07ms)   | decode as datasource_pbf: bench/enf.t5yd5cdi_14_13089_8506.vector.pbf
+2142.56ms (cpu 2140.40ms)   | decode as datasource: bench/enf.t5yd5cdi_14_13089_8506.vector.pbf
+processed 6800 features
+
+
+with bbox filter:
+
+$ .//build/Release/vtile-decode bench/enf.t5yd5cdi_14_13089_8506.vector.pbf 14 13089 8506 200
+z:14 x:13089 y:8506 iterations:200
+2497.01ms (cpu 2493.40ms)   | decode as datasource_pbf: bench/enf.t5yd5cdi_14_13089_8506.vector.pbf
+1753.55ms (cpu 1751.10ms)   | decode as datasource: bench/enf.t5yd5cdi_14_13089_8506.vector.pbf
+processed 6600 features
+
+$ ./build/Release/vtile-decode bench/multi_line_13_1310_3166.vector.pbf 13 1310 3166 100
+z:13 x:1310 y:3166 iterations:100
+message: zlib compressed
+4090.67ms (cpu 4083.65ms)   | decode as datasource_pbf: bench/multi_line_13_1310_3166.vector.pbf

--- a/src/vector_tile_datasource.ipp
+++ b/src/vector_tile_datasource.ipp
@@ -35,6 +35,10 @@
 #include <boost/optional.hpp>
 #include <unicode/unistr.h>
 
+#if defined(DEBUG)
+#include <mapnik/debug.hpp>
+#endif
+
 namespace mapnik { namespace vector_tile_impl {
 
     void add_attributes(mapnik::feature_ptr feature,
@@ -196,16 +200,19 @@ namespace mapnik { namespace vector_tile_impl {
                     continue;
                 }
                 mapnik::vector_tile_impl::Geometry geoms(f,tile_x_, tile_y_, scale_, -1*scale_);
-                mapnik::geometry::geometry<double> geom = decode_geometry(geoms, f.type());
+                mapnik::geometry::geometry<double> geom = decode_geometry(geoms, f.type(), filter_.box_);
                 if (geom.is<mapnik::geometry::geometry_empty>())
                 {
                     continue;
                 }
+                #if defined(DEBUG)
                 mapnik::box2d<double> envelope = mapnik::geometry::envelope(geom);
                 if (!filter_.pass(envelope))
                 {
+                    MAPNIK_LOG_ERROR(tile_datasource_pbf) << "tile_datasource: filter:pass should not get here";
                     continue;
                 }
+                #endif
                 mapnik::feature_ptr feature = mapnik::feature_factory::create(ctx_,feature_id);
                 feature->set_geometry(std::move(geom));
                 add_attributes(feature,f,layer_,tr_);

--- a/src/vector_tile_datasource_pbf.ipp
+++ b/src/vector_tile_datasource_pbf.ipp
@@ -32,6 +32,10 @@
 #include <boost/optional.hpp>
 #include <unicode/unistr.h>
 
+#if defined(DEBUG)
+#include <mapnik/debug.hpp>
+#endif
+
 namespace mapnik { namespace vector_tile_impl {
 
     template <typename Filter>
@@ -210,16 +214,19 @@ namespace mapnik { namespace vector_tile_impl {
                             {
                                 auto geom_itr = f.get_packed_uint32();
                                 mapnik::vector_tile_impl::GeometryPBF geoms(geom_itr, tile_x_,tile_y_,scale_,-1*scale_);
-                                mapnik::geometry::geometry<double> geom = decode_geometry(geoms, geometry_type);
+                                mapnik::geometry::geometry<double> geom = decode_geometry(geoms, geometry_type, filter_.box_);
                                 if (geom.is<mapnik::geometry::geometry_empty>())
                                 {
                                     continue;
                                 }
+                                #if defined(DEBUG)
                                 mapnik::box2d<double> envelope = mapnik::geometry::envelope(geom);
                                 if (!filter_.pass(envelope))
                                 {
+                                    MAPNIK_LOG_ERROR(tile_datasource_pbf) << "tile_datasource_pbf: filter:pass should not get here";
                                     continue;
                                 }
+                                #endif
                                 feature->set_geometry(std::move(geom));
                                 return feature;
                             }

--- a/src/vector_tile_geometry_decoder.hpp
+++ b/src/vector_tile_geometry_decoder.hpp
@@ -213,6 +213,11 @@ void decode_point(mapnik::geometry::geometry<double> & geom, T & paths, mapnik::
     std::uint32_t len;
     while ((cmd = paths.next(x1, y1, len)) != T::end)
     {
+        // TODO: consider profiling and trying to optimize this further
+        // when all points are within the bbox filter then the `mp.reserve` should be
+        // perfect, but when some points are thrown out we will allocate more than needed
+        // the "all points intersect" case I think is going to be more common/important
+        // however worth a future look to see if the "some or few points intersect" can be optimized
         if (first)
         {
             first = false;


### PR DESCRIPTION
This optimizes geometry decoding. Currently in `tile_datasource` and `tile_datasource_pbf` we:

1) decode all geometries
2) then call `mapnik::geometry::envelope(geom)`
3) then throw out any geometries that don't intersect with the query box.

This change makes this more efficient:

- each geometry part is thrown out on the fly during decoding
- this allows us to throw out parts of multigeometries that don't occur within the query bbox (potentially speeding up rendering which will need to do less work)
- this also allows us to avoid the overhead of calling `mapnik::geometry::envelope(geom)`. (which I've seen take 5-10% of the time in profiling the `vtile-decode` benchmark)

Profiling shows some overhead to calling `bbox.intersect` per vertex for lines and polygons, so the win is slightly less than for multipoints. The `bbox.intersect` overhead however is more like 2-3% of time (vs the 5-10% of time for `mapnik::geometry::envelope(geom)`).

So, overall we see improvements from this pull like:

Before:

```
$ .//build/Release/vtile-decode bench/enf.t5yd5cdi_14_13089_8506.vector.pbf 14 13089 8506 200
z:14 x:13089 y:8506 iterations:200
2822.66ms (cpu 2821.10ms)   | decode as datasource_pbf: bench/enf.t5yd5cdi_14_13089_8506.vector.pbf
2070.90ms (cpu 2070.44ms)   | decode as datasource: bench/enf.t5yd5cdi_14_13089_8506.vector.pbf
processed 6800 features
```

After:

```
$ .//build/Release/vtile-decode bench/enf.t5yd5cdi_14_13089_8506.vector.pbf 14 13089 8506 200
z:14 x:13089 y:8506 iterations:200
2497.01ms (cpu 2493.40ms)   | decode as datasource_pbf: bench/enf.t5yd5cdi_14_13089_8506.vector.pbf
1753.55ms (cpu 1751.10ms)   | decode as datasource: bench/enf.t5yd5cdi_14_13089_8506.vector.pbf
processed 6600 features
```