### PR TITLE
Geometry tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/geometry-test-data"]
+	path = test/geometry-test-data
+	url = https://github.com/mapnik/geometry-test-data.git

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,10 @@ build/Makefile: ./deps/gyp ./deps/clipper ./deps/protozero gyp/build.gyp test/*c
 libvtile: build/Makefile Makefile
 	@$(MAKE) -C build/ BUILDTYPE=$(BUILDTYPE) V=$(V)
 
-test: libvtile
+test/geometry-test-data:
+	git submodule update --init
+
+test: libvtile test/geometry-test-data
 	./build/$(BUILDTYPE)/tests
 
 testpack:

--- a/test/encoding_util.cpp
+++ b/test/encoding_util.cpp
@@ -1,0 +1,131 @@
+#include <mapnik/vertex.hpp>
+#include <mapnik/geometry.hpp>
+#include <mapnik/geometry_adapters.hpp>
+#include <mapnik/vertex_processor.hpp>
+#include "vector_tile_geometry_decoder.hpp"
+#include "vector_tile_geometry_encoder.hpp"
+
+namespace {
+
+using namespace mapnik::geometry;
+
+struct print
+{
+    void operator() (geometry_empty const&) const
+    {
+        std::cerr << "EMPTY" << std::endl;
+    }
+    template <typename T>
+    void operator() (geometry_collection<T> const&) const
+    {
+        std::cerr << "COLLECTION" << std::endl;
+    }
+    template <typename T>
+    void operator() (T const& geom) const
+    {
+        std::cerr << boost::geometry::wkt(geom) << std::endl;
+    }
+};
+
+}
+
+struct show_path
+{
+    std::string & str_;
+    show_path(std::string & out) :
+      str_(out) {}
+
+    template <typename T>
+    void operator()(T & path)
+    {
+        unsigned cmd = -1;
+        double x = 0;
+        double y = 0;
+        std::ostringstream s;
+        path.rewind(0);
+        while ((cmd = path.vertex(&x, &y)) != mapnik::SEG_END)
+        {
+            switch (cmd)
+            {
+                case mapnik::SEG_MOVETO: s << "move_to("; break;
+                case mapnik::SEG_LINETO: s << "line_to("; break;
+                case mapnik::SEG_CLOSE: s << "close_path("; break;
+                default: std::clog << "unhandled cmd " << cmd << "\n"; break;
+            }
+            s << x << "," << y << ")\n";
+        }
+        str_ += s.str();
+    }
+};
+
+struct encoder_visitor
+{
+    vector_tile::Tile_Feature & feature_;
+    int32_t x_;
+    int32_t y_;
+    encoder_visitor(vector_tile::Tile_Feature & feature) :
+      feature_(feature),
+      x_(0),
+      y_(0) { }
+
+    void operator() (geometry_empty const&)
+    {
+    }
+
+    void operator()(mapnik::geometry::geometry_collection<std::int64_t> const& path)
+    {
+        for (auto const& p : path)
+        {
+            mapnik::util::apply_visitor((*this), p);
+        }
+    }
+
+    template <typename T>
+    void operator()(T const& geom)
+    {
+        mapnik::vector_tile_impl::encode_geometry(geom,feature_,x_,y_);
+    }
+};
+
+vector_tile::Tile_Feature geometry_to_feature(mapnik::geometry::geometry<std::int64_t> const& g)
+{
+    vector_tile::Tile_Feature feature;
+    if (g.template is<mapnik::geometry::point<std::int64_t>>() || g.template is<mapnik::geometry::multi_point<std::int64_t>>())
+    {
+        feature.set_type(vector_tile::Tile_GeomType_POINT);
+    }
+    else if (g.template is<mapnik::geometry::line_string<std::int64_t>>() || g.template is<mapnik::geometry::multi_line_string<std::int64_t>>())
+    {
+        feature.set_type(vector_tile::Tile_GeomType_LINESTRING);
+    }
+    else if (g.template is<mapnik::geometry::polygon<std::int64_t>>() || g.template is<mapnik::geometry::multi_polygon<std::int64_t>>())
+    {
+        feature.set_type(vector_tile::Tile_GeomType_POLYGON);
+    }
+    else
+    {
+        throw std::runtime_error("could not detect valid geometry type");
+    }
+    encoder_visitor ap(feature);
+    mapnik::util::apply_visitor(ap,g);
+    return feature;
+}
+
+template <typename T>
+std::string decode_to_path_string(mapnik::geometry::geometry<T> const& g)
+{
+    //mapnik::util::apply_visitor(print(), g2);
+    using decode_path_type = mapnik::geometry::vertex_processor<show_path>;
+    std::string out;
+    show_path sp(out);
+    mapnik::util::apply_visitor(decode_path_type(sp), g);
+    return out;
+}
+
+std::string compare(mapnik::geometry::geometry<std::int64_t> const& g)
+{
+    vector_tile::Tile_Feature feature = geometry_to_feature(g);
+    mapnik::vector_tile_impl::Geometry<double> geoms(feature,0.0,0.0,1.0,1.0);
+    auto g2 = mapnik::vector_tile_impl::decode_geometry<double>(geoms,feature.type());
+    return decode_to_path_string(g2);
+}

--- a/test/encoding_util.hpp
+++ b/test/encoding_util.hpp
@@ -9,123 +9,17 @@ namespace {
 
 using namespace mapnik::geometry;
 
-struct print
-{
-    void operator() (geometry_empty const&) const
-    {
-        std::cerr << "EMPTY" << std::endl;
-    }
-    template <typename T>
-    void operator() (geometry_collection<T> const&) const
-    {
-        std::cerr << "COLLECTION" << std::endl;
-    }
-    template <typename T>
-    void operator() (T const& geom) const
-    {
-        std::cerr << boost::geometry::wkt(geom) << std::endl;
-    }
-};
+struct print;
 
 }
 
-struct show_path
-{
-    std::string & str_;
-    show_path(std::string & out) :
-      str_(out) {}
+struct show_path;
 
-    template <typename T>
-    void operator()(T & path)
-    {
-        unsigned cmd = -1;
-        double x = 0;
-        double y = 0;
-        std::ostringstream s;
-        path.rewind(0);
-        while ((cmd = path.vertex(&x, &y)) != mapnik::SEG_END)
-        {
-            switch (cmd)
-            {
-                case mapnik::SEG_MOVETO: s << "move_to("; break;
-                case mapnik::SEG_LINETO: s << "line_to("; break;
-                case mapnik::SEG_CLOSE: s << "close_path("; break;
-                default: std::clog << "unhandled cmd " << cmd << "\n"; break;
-            }
-            s << x << "," << y << ")\n";
-        }
-        str_ += s.str();
-    }
-};
+struct encoder_visitor;
 
-struct encoder_visitor
-{
-    vector_tile::Tile_Feature & feature_;
-    int32_t x_;
-    int32_t y_;
-    encoder_visitor(vector_tile::Tile_Feature & feature) :
-      feature_(feature),
-      x_(0),
-      y_(0) { }
-
-    void operator() (geometry_empty const&)
-    {
-    }
-
-    void operator()(mapnik::geometry::geometry_collection<std::int64_t> const& path)
-    {
-        for (auto const& p : path)
-        {
-            mapnik::util::apply_visitor((*this), p);
-        }
-    }
-
-    template <typename T>
-    void operator()(T const& geom)
-    {
-        mapnik::vector_tile_impl::encode_geometry(geom,feature_,x_,y_);
-    }
-};
-
-vector_tile::Tile_Feature geometry_to_feature(mapnik::geometry::geometry<std::int64_t> const& g)
-{
-    vector_tile::Tile_Feature feature;
-    if (g.template is<mapnik::geometry::point<std::int64_t>>() || g.template is<mapnik::geometry::multi_point<std::int64_t>>())
-    {
-        feature.set_type(vector_tile::Tile_GeomType_POINT);
-    }
-    else if (g.template is<mapnik::geometry::line_string<std::int64_t>>() || g.template is<mapnik::geometry::multi_line_string<std::int64_t>>())
-    {
-        feature.set_type(vector_tile::Tile_GeomType_LINESTRING);
-    }
-    else if (g.template is<mapnik::geometry::polygon<std::int64_t>>() || g.template is<mapnik::geometry::multi_polygon<std::int64_t>>())
-    {
-        feature.set_type(vector_tile::Tile_GeomType_POLYGON);
-    }
-    else
-    {
-        throw std::runtime_error("could not detect valid geometry type");
-    }
-    encoder_visitor ap(feature);
-    mapnik::util::apply_visitor(ap,g);
-    return feature;
-}
+vector_tile::Tile_Feature geometry_to_feature(mapnik::geometry::geometry<std::int64_t> const& g);
 
 template <typename T>
-std::string decode_to_path_string(mapnik::geometry::geometry<T> const& g)
-{
-    //mapnik::util::apply_visitor(print(), g2);
-    using decode_path_type = mapnik::geometry::vertex_processor<show_path>;
-    std::string out;
-    show_path sp(out);
-    mapnik::util::apply_visitor(decode_path_type(sp), g);
-    return out;
-}
+std::string decode_to_path_string(mapnik::geometry::geometry<T> const& g);
 
-std::string compare(mapnik::geometry::geometry<std::int64_t> const& g)
-{
-    vector_tile::Tile_Feature feature = geometry_to_feature(g);
-    mapnik::vector_tile_impl::Geometry<double> geoms(feature,0.0,0.0,1.0,1.0);
-    auto g2 = mapnik::vector_tile_impl::decode_geometry<double>(geoms,feature.type());
-    return decode_to_path_string(g2);
-}
+std::string compare(mapnik::geometry::geometry<std::int64_t> const& g);

--- a/test/geometry_visual_test.cpp
+++ b/test/geometry_visual_test.cpp
@@ -1,0 +1,243 @@
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <cmath>
+#include <mapnik/util/fs.hpp>
+#include <mapnik/projection.hpp>
+#include <mapnik/geometry_transform.hpp>
+#include <mapnik/util/geometry_to_geojson.hpp>
+#include <mapnik/geometry_correct.hpp>
+#include <mapnik/util/file_io.hpp>
+#include <mapnik/save_map.hpp>
+#include <mapnik/geometry_reprojection.hpp>
+#include <mapnik/geometry_strategy.hpp>
+#include <mapnik/proj_strategy.hpp>
+#include <mapnik/view_strategy.hpp>
+#include <mapnik/geometry_is_valid.hpp>
+#include <mapnik/geometry_is_simple.hpp>
+
+#include "catch.hpp"
+#include "encoding_util.hpp"
+#include "test_utils.hpp"
+#include "vector_tile_strategy.hpp"
+#include "vector_tile_processor.hpp"
+#include "vector_tile_backend_pbf.hpp"
+#include "vector_tile_projection.hpp"
+#include "vector_tile_geometry_decoder.hpp"
+#include <boost/filesystem/operations.hpp>
+
+void clip_geometry(std::string const& file,
+                   mapnik::box2d<double> const& bbox,
+                   int simplify_distance,
+                   bool strictly_simple)
+{
+    typedef mapnik::vector_tile_impl::backend_pbf backend_type;
+    typedef mapnik::vector_tile_impl::processor<backend_type> renderer_type;
+    typedef vector_tile::Tile tile_type;
+    std::string geojson_string;
+    std::shared_ptr<mapnik::memory_datasource> ds = testing::build_geojson_ds(file);
+    tile_type tile;
+    backend_type backend(tile,1000);
+
+    mapnik::Map map(256,256,"+init=epsg:4326");
+    mapnik::layer lyr("layer","+init=epsg:4326");
+    lyr.set_datasource(ds);
+    map.add_layer(lyr);
+    map.zoom_to_box(bbox);
+    mapnik::request m_req(map.width(),map.height(),map.get_current_extent());
+    renderer_type ren(
+        backend,
+        map,
+        m_req,
+        1.0,
+        0,
+        0,
+        0.1,
+        strictly_simple
+    );
+    ren.set_simplify_distance(simplify_distance);
+    ren.apply();
+    std::string buffer;
+    tile.SerializeToString(&buffer);
+    if (buffer.size() > 0 && tile.layers_size() > 0 && tile.layers_size() != false)
+    {
+        vector_tile::Tile_Layer const& layer = tile.layers(0);
+        if (layer.features_size() != false)
+        {
+            vector_tile::Tile_Feature const& f = layer.features(0);
+            mapnik::vector_tile_impl::Geometry<double> geoms(f,0.0,0.0,32.0,32.0);
+            mapnik::geometry::geometry<double> geom = mapnik::vector_tile_impl::decode_geometry<double>(geoms,f.type());
+            mapnik::geometry::scale_strategy ss(1.0/32.0);
+            mapnik::view_transform vt(256, 256, bbox);
+            mapnik::unview_strategy uvs(vt);
+            using sg_type = strategy_group_first<mapnik::geometry::scale_strategy, mapnik::unview_strategy >;
+            sg_type sg(ss, uvs);
+            mapnik::geometry::geometry<double> geom4326 = transform<double>(geom, sg);
+            std::string reason;
+            std::string is_valid = "false";
+            std::string is_simple = "false";
+            if (mapnik::geometry::is_valid(geom4326, reason))
+                is_valid = "true";
+            if (mapnik::geometry::is_simple(geom4326))
+                is_simple = "true";
+
+            unsigned int n_err = 0;
+            mapnik::util::to_geojson(geojson_string,geom4326);
+
+            geojson_string = geojson_string.substr(0, geojson_string.size()-1);
+            geojson_string += ",\"properties\":{\"is_valid\":"+is_valid+", \"is_simple\":"+is_simple+", \"message\":\""+reason+"\"}}";
+        }
+        else
+        {
+            geojson_string = "{\"type\": \"Feature\", \"coordinates\":null, \"properties\":{\"message\":\"Tile layer had no features\"}}";
+        }
+    }
+    else
+    {
+        geojson_string = "{\"type\": \"Feature\", \"coordinates\":null, \"properties\":{\"message\":\"Tile had no layers\"}}";
+    }
+
+    std::string fixture_name = mapnik::util::basename(file);
+    fixture_name = fixture_name.substr(0, fixture_name.size()-5);
+    if (!mapnik::util::exists("./test/geometry-test-data/output"))
+    {
+        boost::filesystem::create_directory(("./test/geometry-test-data/output"));
+    }
+    if (!mapnik::util::exists("./test/geometry-test-data/output/"+fixture_name))
+    {
+        boost::filesystem::create_directory(("./test/geometry-test-data/output/"+fixture_name));
+    }
+
+    std::stringstream file_stream;
+    file_stream << "./test/geometry-test-data/output/" << fixture_name << "/"
+        << bbox.minx() << ","
+        << bbox.miny() << ","
+        << bbox.maxx()<< ","
+        << bbox.maxy() << ","
+        << "simplify_distance=" << simplify_distance << ","
+        << "strictly_simple=" << strictly_simple << ".geojson";
+    std::string file_path = file_stream.str();
+    if (!mapnik::util::exists(file_path) || (std::getenv("UPDATE") != nullptr))
+    {
+        std::ofstream out(file_path);
+        out << geojson_string;
+    }
+    else
+    {
+        mapnik::util::file input(file_path);
+        if (!input.open())
+        {
+            throw std::runtime_error("failed to open geojson");
+        }
+        mapnik::geometry::geometry<double> geom;
+        std::string expected_string(input.data().get(), input.size());
+        REQUIRE(expected_string == geojson_string);
+    }
+}
+
+mapnik::box2d<double> middle_fifty(mapnik::box2d<double> const& bbox)
+{
+    double width = std::fabs(bbox.maxx() - bbox.minx());
+    double height = std::fabs(bbox.maxy() - bbox.miny());
+    mapnik::box2d<double> new_bbox(
+        bbox.minx() + width*0.25,
+        bbox.miny() + height*0.25,
+        bbox.maxx() - width*0.25,
+        bbox.maxy() - height*0.25
+    );
+    return new_bbox;
+}
+
+mapnik::box2d<double> top_left(mapnik::box2d<double> const& bbox)
+{
+    double width = std::fabs(bbox.maxx() - bbox.minx());
+    double height = std::fabs(bbox.maxy() - bbox.miny());
+    mapnik::box2d<double> new_bbox(
+        bbox.minx(),
+        bbox.miny(),
+        bbox.maxx() - width*0.5,
+        bbox.maxy() - height*0.5
+    );
+    return new_bbox;
+}
+
+mapnik::box2d<double> top_right(mapnik::box2d<double> const& bbox)
+{
+    double width = std::fabs(bbox.maxx() - bbox.minx());
+    double height = std::fabs(bbox.maxy() - bbox.miny());
+    mapnik::box2d<double> new_bbox(
+        bbox.minx() + width*0.5,
+        bbox.miny(),
+        bbox.maxx(),
+        bbox.maxy() - height*0.5
+    );
+    return new_bbox;
+}
+
+mapnik::box2d<double> bottom_left(mapnik::box2d<double> const& bbox)
+{
+    double width = std::fabs(bbox.maxx() - bbox.minx());
+    double height = std::fabs(bbox.maxy() - bbox.miny());
+    mapnik::box2d<double> new_bbox(
+        bbox.minx(),
+        bbox.miny() + height*0.5,
+        bbox.maxx() + width*0.5,
+        bbox.maxy()
+    );
+    return new_bbox;
+}
+
+mapnik::box2d<double> bottom_right(mapnik::box2d<double> const& bbox)
+{
+    double width = std::fabs(bbox.maxx() - bbox.minx());
+    double height = std::fabs(bbox.maxy() - bbox.miny());
+    mapnik::box2d<double> new_bbox(
+        bbox.minx() + width*0.5,
+        bbox.miny() + height*0.5,
+        bbox.maxx(),
+        bbox.maxy()
+    );
+    return new_bbox;
+}
+
+mapnik::box2d<double> zoomed_out(mapnik::box2d<double> const& bbox)
+{
+    double width = std::fabs(bbox.maxx() - bbox.minx());
+    double height = std::fabs(bbox.maxy() - bbox.miny());
+    mapnik::box2d<double> new_bbox(
+        bbox.minx() - width,
+        bbox.miny() - height,
+        bbox.maxx() + width,
+        bbox.maxy() + height
+    );
+    return new_bbox;
+}
+
+TEST_CASE( "geometries", "should reproject, clip, and simplify")
+{
+
+    std::vector<std::string> geometries = mapnik::util::list_directory("./test/geometry-test-data/input");
+    std::vector<std::string> benchmarks = mapnik::util::list_directory("./test/geometry-test-data/benchmark");
+    if (std::getenv("BENCHMARK") != nullptr)
+    {
+        geometries.insert(geometries.end(), benchmarks.begin(), benchmarks.end());
+    }
+    for (std::string const& file: geometries)
+    {
+        std::shared_ptr<mapnik::memory_datasource> ds = testing::build_geojson_ds(file);
+        mapnik::box2d<double> bbox = ds->envelope();
+        for (int simplification_distance: std::vector<int>({0, 4, 8}))
+        {
+            for (bool strictly_simple: std::vector<bool>({false, true}))
+            {
+                clip_geometry(file, bbox, simplification_distance, strictly_simple);
+                clip_geometry(file, middle_fifty(bbox), simplification_distance, strictly_simple);
+                clip_geometry(file, top_left(bbox), simplification_distance, strictly_simple);
+                clip_geometry(file, top_right(bbox), simplification_distance, strictly_simple);
+                clip_geometry(file, bottom_left(bbox), simplification_distance, strictly_simple);
+                clip_geometry(file, bottom_right(bbox), simplification_distance, strictly_simple);
+                clip_geometry(file, zoomed_out(bbox), simplification_distance, strictly_simple);
+            }
+        }
+    }
+}

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,4 +1,4 @@
-// https://github.com/philsquared/Catch/wiki/Supplying-your-own-main()
+// https://github.com/philsquared/Catch/blob/master/docs/own-main.md
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 

--- a/test/vector_tile_projection.cpp
+++ b/test/vector_tile_projection.cpp
@@ -2,8 +2,56 @@
 
 #include <mapnik/projection.hpp>
 #include <mapnik/box2d.hpp>
+#include <mapnik/well_known_srs.hpp>
 #include <mapnik/proj_transform.hpp>
 #include "vector_tile_projection.hpp"
+
+std::vector<double> pointToTile(double lon, double lat, unsigned z)
+{
+    double s = std::sin(lat * M_PI / 180.0);
+    double z2 = std::pow(2.0,z);
+    double x = z2 * (lon / 360.0 + 0.5);
+    double y = z2 * (0.5 - 0.25 * std::log((1 + s) / (1 - s)) / M_PI) - 1;
+    return { x, y };
+}
+
+int getBboxZoom(std::vector<double> const& bbox)
+{
+    int MAX_ZOOM = 32;
+    for (int z = 0; z < MAX_ZOOM; z++) {
+        int mask = (1 << (32 - (z + 1)));
+        if (((static_cast<int>(bbox[0]) & mask) != (static_cast<int>(bbox[2]) & mask)) ||
+            ((static_cast<int>(bbox[1]) & mask) != (static_cast<int>(bbox[3]) & mask))) {
+            return z;
+        }
+    }
+
+    return MAX_ZOOM;
+}
+
+std::vector<unsigned> bboxToXYZ(mapnik::box2d<double> const& bboxCoords)
+{
+    double minx = bboxCoords.minx();
+    double miny = bboxCoords.miny();
+    double maxx = bboxCoords.maxx();
+    double maxy = bboxCoords.maxy();
+    mapnik::merc2lonlat(&minx,&miny,1);
+    mapnik::merc2lonlat(&maxx,&maxy,1);
+
+    std::vector<double> ubbox = {
+        minx,
+        miny,
+        maxx,
+        maxy
+    };
+    unsigned z = getBboxZoom(ubbox);
+    if (z == 0) return {0, 0, 0};
+    minx = pointToTile(minx, miny, 32)[0];
+    miny = pointToTile(minx, miny, 32)[1];
+    unsigned x = static_cast<unsigned>(minx);
+    unsigned y = static_cast<unsigned>(miny);
+    return {x, y, z};
+}
 
 TEST_CASE( "vector tile projection 1", "should support z/x/y to bbox conversion at 0/0/0" ) {
     mapnik::vector_tile_impl::spherical_mercator merc(256);
@@ -16,6 +64,12 @@ TEST_CASE( "vector tile projection 1", "should support z/x/y to bbox conversion 
     CHECK(std::fabs(map_extent.miny() - e.miny()) < epsilon);
     CHECK(std::fabs(map_extent.maxx() - e.maxx()) < epsilon);
     CHECK(std::fabs(map_extent.maxy() - e.maxy()) < epsilon);
+    auto xyz = bboxToXYZ(map_extent);
+    /*
+    CHECK(xyz[0] == 0);
+    CHECK(xyz[1] == 0);
+    CHECK(xyz[2] == 0);
+    */
 }
 
 TEST_CASE( "vector tile projection 2", "should support z/x/y to bbox conversion up to z33" ) {
@@ -32,4 +86,32 @@ TEST_CASE( "vector tile projection 2", "should support z/x/y to bbox conversion 
     CHECK(std::fabs(map_extent.miny() - e.miny()) < epsilon);
     CHECK(std::fabs(map_extent.maxx() - e.maxx()) < epsilon);
     CHECK(std::fabs(map_extent.maxy() - e.maxy()) < epsilon);
+    auto xyz = bboxToXYZ(map_extent);
+    /*
+    CHECK(xyz[0] == x);
+    CHECK(xyz[1] == y);
+    CHECK(xyz[2] == z);
+    */
+}
+
+TEST_CASE( "vector tile projection 3", "should support z/x/y to bbox conversion for z3" ) {
+    mapnik::vector_tile_impl::spherical_mercator merc(256);
+    int x = 3;
+    int y = 3;
+    int z = 3;
+    double minx,miny,maxx,maxy;
+    merc.xyz(x,y,z,minx,miny,maxx,maxy);
+    mapnik::box2d<double> map_extent(minx,miny,maxx,maxy);
+    mapnik::box2d<double> e(-5009377.085697311,0.0,0.0,5009377.085697311);
+    double epsilon = 0.00000001;
+    CHECK(std::fabs(map_extent.minx() - e.minx()) < epsilon);
+    CHECK(std::fabs(map_extent.miny() - e.miny()) < epsilon);
+    CHECK(std::fabs(map_extent.maxx() - e.maxx()) < epsilon);
+    CHECK(std::fabs(map_extent.maxy() - e.maxy()) < epsilon);
+    auto xyz = bboxToXYZ(map_extent);
+    /*
+    CHECK(xyz[0] == x);
+    CHECK(xyz[1] == y);
+    CHECK(xyz[2] == z);
+    */
 }


### PR DESCRIPTION
This pull request adds [geometry test data](https://github.com/mapnik/geometry-test-data) to mapnik-vector-tile tests, with the goal of improving coverage and making mapnik-vector-tile robust against various invalid and bad geometries. The current strategy for these tests is:

1. Create many problematic and non-problematic vector files and place them in https://github.com/mapnik/geometry-test-data `input` folder.
2. Run a test that reads the input vector file and performs the clipping and simplification of the vector-tile production process.
3. Compare the resulting clipped-and-simplified tile to a corresponding expected tile in the `expected` folder of geometry-test-data.

refs #153 

cc/ @flippmoke, @springmeyer, @artemp 