### PR TITLE
Handle invalid geometries in layer encoding

### DIFF
--- a/src/vector_tile_geometry_feature.hpp
+++ b/src/vector_tile_geometry_feature.hpp
@@ -63,11 +63,11 @@ struct geometry_to_feature_pbf_visitor
                 feature_writer.add_packed_uint32(Feature_Encoding::TAGS, feature_tags.begin(), feature_tags.end());
                 builder_.make_not_empty();
             }
+            else
+            {
+                feature_writer.rollback();
+            }
         }   
-        if (!success)
-        {
-            layer_writer.rollback();
-        }
     }
 
     void operator() (mapnik::geometry::geometry_collection<std::int64_t> const& collection)

--- a/test/unit/encoding/geometry_to_feature_pbf.cpp
+++ b/test/unit/encoding/geometry_to_feature_pbf.cpp
@@ -1,0 +1,41 @@
+#include "catch.hpp"
+
+// mapnik vector tile
+#include "vector_tile_geometry_feature.hpp"
+#include "vector_tile_layer.hpp"
+
+// mapnik
+#include <mapnik/geometry.hpp>
+#include <mapnik/feature.hpp>
+#include <mapnik/feature_factory.hpp>
+#include <mapnik/util/variant.hpp>
+
+// protozero
+#include <protozero/pbf_writer.hpp>
+
+// libprotobuf
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#include "vector_tile.pb.h"
+#pragma GCC diagnostic pop
+
+// std
+#include <limits>
+
+//
+// Unit tests for encoding of geometries to features
+//
+
+TEST_CASE("encode feature pbf of degenerate linestring")
+{
+    mapnik::geometry::line_string<std::int64_t> line;
+    line.add_coord(10,10);
+
+    std::string layer_buffer = "";
+    mapnik::vector_tile_impl::layer_builder_pbf layer("foo", 4096, layer_buffer);
+    mapnik::feature_ptr f(mapnik::feature_factory::create(std::make_shared<mapnik::context_type>(),1));
+    mapnik::vector_tile_impl::geometry_to_feature_pbf_visitor visitor(*f, layer);
+    visitor(line);
+    REQUIRE(layer_buffer == "");
+}

--- a/test/unit/encoding/geometry_to_feature_pbf.cpp
+++ b/test/unit/encoding/geometry_to_feature_pbf.cpp
@@ -29,6 +29,13 @@
 
 TEST_CASE("encode feature pbf of degenerate linestring")
 {
+    mapnik::geometry::geometry_empty empty;
+    std::string empty_buffer = "";
+    mapnik::vector_tile_impl::layer_builder_pbf empty_layer("foo", 4096, empty_buffer);
+    mapnik::feature_ptr empty_feature(mapnik::feature_factory::create(std::make_shared<mapnik::context_type>(),1));
+    mapnik::vector_tile_impl::geometry_to_feature_pbf_visitor empty_visitor(*empty_feature, empty_layer);
+    empty_visitor(empty);
+
     mapnik::geometry::line_string<std::int64_t> line;
     line.add_coord(10,10);
 
@@ -37,5 +44,7 @@ TEST_CASE("encode feature pbf of degenerate linestring")
     mapnik::feature_ptr f(mapnik::feature_factory::create(std::make_shared<mapnik::context_type>(),1));
     mapnik::vector_tile_impl::geometry_to_feature_pbf_visitor visitor(*f, layer);
     visitor(line);
-    REQUIRE(layer_buffer == "");
+
+    REQUIRE(layer_buffer == empty_buffer);
+    REQUIRE(layer.empty == true);
 }


### PR DESCRIPTION
Prevent the segfaults that occur when invalid geometries are passed to the layer encoder by rolling back any written geometries, rather than rolling back the entire layer writer.

Note, with this fix, the keys and values added by the invalid feature will stay in the layer, which I think is acceptable for the edge case situation.

cc/ @springmeyer @flippmoke 