### PR TITLE
Update to deal with move of geometry adapter in mapnik

### DIFF
--- a/src/vector_tile_geometry_clipper.hpp
+++ b/src/vector_tile_geometry_clipper.hpp
@@ -8,7 +8,7 @@
 // mapnik
 #include <mapnik/box2d.hpp>
 #include <mapnik/geometry.hpp>
-#include <mapnik/geometry_adapters.hpp>
+#include <mapnik/geometry/boost_geometry_adapters.hpp>
 
 // angus clipper
 // http://www.angusj.com/delphi/clipper.php

--- a/src/vector_tile_geometry_simplifier.hpp
+++ b/src/vector_tile_geometry_simplifier.hpp
@@ -7,7 +7,7 @@
 
 // mapnik
 #include <mapnik/geometry.hpp>
-#include <mapnik/geometry_adapters.hpp>
+#include <mapnik/geometry/boost_geometry_adapters.hpp>
 
 namespace mapnik
 {

--- a/test/utils/encoding_util.cpp
+++ b/test/utils/encoding_util.cpp
@@ -7,7 +7,7 @@
 // mapnik
 #include <mapnik/vertex.hpp>
 #include <mapnik/geometry.hpp>
-#include <mapnik/geometry_adapters.hpp>
+#include <mapnik/geometry/boost_geometry_adapters.hpp>
 #include <mapnik/vertex_processor.hpp>
 
 // test utils


### PR DESCRIPTION
Fixes compilation error caused by this change in Mapnik: https://github.com/mapnik/mapnik/commit/caa03d78bdea32d7bba7a528182f8ab41e622330

@springmeyer 