### PR TITLE
Mark the .proto as proto2 syntax

### DIFF
--- a/proto/vector_tile.proto
+++ b/proto/vector_tile.proto
@@ -1,5 +1,7 @@
 // Protocol Version 1
 
+syntax = "proto2";
+
 package vector_tile;
 
 option optimize_for = LITE_RUNTIME;


### PR DESCRIPTION
This allows the .proto to be used with libprotobuf >= 3.x without warnings.