### PR TITLE
Pass variables to replace tokens in query

### DIFF
--- a/src/vector_tile_layer.hpp
+++ b/src/vector_tile_layer.hpp
@@ -95,7 +95,8 @@ public:
                double scale_factor,
                double scale_denom,
                int offset_x,
-               int offset_y)
+               int offset_y,
+               mapnik::attributes const& vars)
         : valid_(true),
           ds_(lay.datasource()),
           target_proj_(map.srs(), true),
@@ -106,7 +107,7 @@ public:
           layer_extent_(calc_extent(tile_size)),
           target_buffered_extent_(calc_target_buffered_extent(tile_extent_bbox, buffer_size, lay, map)),
           source_buffered_extent_(calc_source_buffered_extent()),
-          query_(calc_query(scale_factor, scale_denom, tile_extent_bbox, lay)),
+          query_(calc_query(scale_factor, scale_denom, tile_extent_bbox, lay, vars)),
           view_trans_(layer_extent_, layer_extent_, tile_extent_bbox, offset_x, offset_y),
           empty_(true),
           painted_(false)
@@ -221,7 +222,8 @@ public:
     mapnik::query calc_query(double scale_factor,
                              double scale_denom,
                              mapnik::box2d<double> const& tile_extent_bbox,
-                             mapnik::layer const& lay)
+                             mapnik::layer const& lay,
+                             mapnik::attributes const& vars)
     {
         // Adjust the scale denominator if required
         if (scale_denom <= 0.0)
@@ -293,6 +295,7 @@ public:
                 q.add_property_name(desc.get_name());
             }
         }
+        q.set_variables(vars);
         return q;
     }
 

--- a/src/vector_tile_layer.hpp
+++ b/src/vector_tile_layer.hpp
@@ -309,6 +309,11 @@ public:
         return ds_->features(query_);
     }
 
+    mapnik::query const& get_query() const
+    {
+        return query_;
+    }
+
     mapnik::view_transform const& get_view_transform() const
     {
         return view_trans_;

--- a/src/vector_tile_processor.hpp
+++ b/src/vector_tile_processor.hpp
@@ -6,6 +6,7 @@
 #include <mapnik/image_scaling.hpp>
 #include <mapnik/layer.hpp>
 #include <mapnik/map.hpp>
+#include <mapnik/attribute.hpp>
 #include <mapnik/request.hpp>
 #include <mapnik/util/noncopyable.hpp>
 
@@ -46,9 +47,10 @@ private:
     bool multi_polygon_union_;
     bool process_all_rings_;
     std::launch threading_mode_;
+    mapnik::attributes vars_;
 
 public:
-    processor(mapnik::Map const& map)
+    processor(mapnik::Map const& map, mapnik::attributes const& vars = mapnik::attributes())
         : m_(map),
           image_format_("webp"),
           scale_factor_(1.0),
@@ -59,7 +61,8 @@ public:
           strictly_simple_(true),
           multi_polygon_union_(false),
           process_all_rings_(false),
-          threading_mode_(std::launch::deferred) {}
+          threading_mode_(std::launch::deferred),
+          vars_(vars) {}
 
     MAPNIK_VECTOR_INLINE void update_tile(tile & t,
                                           double scale_denom = 0.0,

--- a/src/vector_tile_processor.hpp
+++ b/src/vector_tile_processor.hpp
@@ -185,6 +185,11 @@ public:
         return image_format_;
     }
 
+    mapnik::attributes const& get_variables() const
+    {
+        return vars_;
+    }
+
     void set_threading_mode(std::launch mode)
     {
         threading_mode_ = mode;

--- a/src/vector_tile_processor.ipp
+++ b/src/vector_tile_processor.ipp
@@ -15,6 +15,7 @@
 #include <mapnik/layer.hpp>
 #include <mapnik/map.hpp>
 #include <mapnik/version.hpp>
+#include <mapnik/attribute.hpp>
 
 #if MAPNIK_VERSION >= 300100
 #include <mapnik/geometry/transform.hpp>
@@ -258,7 +259,8 @@ MAPNIK_VECTOR_INLINE void processor::update_tile(tile & t,
                              scale_factor_,
                              scale_denom,
                              offset_x,
-                             offset_y);
+                             offset_y,
+                             vars_);
         if (!tile_layers.back().is_valid())
         {
             t.add_empty_layer(lay.name());

--- a/test/unit/layer_impl/layer.cpp
+++ b/test/unit/layer_impl/layer.cpp
@@ -22,7 +22,7 @@ TEST_CASE("Vector tile layer class")
         mapnik::layer layer("layer", "+init=epsg:3857");
         layer.set_datasource(ds);
         mapnik::box2d<double> extent(-20037508.342789,-20037508.342789,20037508.342789,20037508.342789);
-        mapnik::attributes empty_vars;
+        const mapnik::attributes empty_vars;
 
         mapnik::vector_tile_impl::tile_layer some_layer(map,
                                                         layer,
@@ -35,5 +35,33 @@ TEST_CASE("Vector tile layer class")
                                                         0, // offset_y
                                                         empty_vars);
         CHECK(some_layer.is_valid());
+    }
+
+    SECTION("The query has the variables passed to the constructor")
+    {
+        mapnik::Map map(256, 256);
+
+        // Create memory datasource
+        mapnik::parameters params;
+        params["type"] = "memory";
+        auto ds = std::make_shared<mapnik::memory_datasource>(params);
+
+        mapnik::layer layer("layer", "+init=epsg:3857");
+        layer.set_datasource(ds);
+        mapnik::box2d<double> extent(-20037508.342789,-20037508.342789,20037508.342789,20037508.342789);
+        const mapnik::attributes vars { {"zoom_level", 20} };
+
+        mapnik::vector_tile_impl::tile_layer some_layer(map,
+                                                        layer,
+                                                        extent,
+                                                        256, // tile_size
+                                                        10, // buffer_size
+                                                        1.0, // scale_factor
+                                                        0, // scale_denom
+                                                        0, // offset_x
+                                                        0, // offset_y
+                                                        vars);
+        CHECK(some_layer.is_valid());
+        CHECK( ( vars == some_layer.get_query().variables() ) );
     }
 }

--- a/test/unit/layer_impl/layer.cpp
+++ b/test/unit/layer_impl/layer.cpp
@@ -1,0 +1,39 @@
+#include "catch.hpp"
+
+// mapnik
+#include <mapnik/map.hpp>
+#include <mapnik/attribute.hpp>
+#include <mapnik/memory_datasource.hpp>
+
+// mapnik vector tile layer class
+#include "vector_tile_layer.hpp"
+
+TEST_CASE("Vector tile layer class")
+{
+    SECTION("The constructor can produce a valid tile_layer with empty vars")
+    {
+        mapnik::Map map(256, 256);
+
+        // Create memory datasource
+        mapnik::parameters params;
+        params["type"] = "memory";
+        auto ds = std::make_shared<mapnik::memory_datasource>(params);
+
+        mapnik::layer layer("layer", "+init=epsg:3857");
+        layer.set_datasource(ds);
+        mapnik::box2d<double> extent(-20037508.342789,-20037508.342789,20037508.342789,20037508.342789);
+        mapnik::attributes empty_vars;
+
+        mapnik::vector_tile_impl::tile_layer some_layer(map,
+                                                        layer,
+                                                        extent,
+                                                        256, // tile_size
+                                                        10, // buffer_size
+                                                        1.0, // scale_factor
+                                                        0, // scale_denom
+                                                        0, // offset_x
+                                                        0, // offset_y
+                                                        empty_vars);
+        CHECK(some_layer.is_valid());
+    }
+}

--- a/test/unit/processor/variables.cpp
+++ b/test/unit/processor/variables.cpp
@@ -1,0 +1,33 @@
+#include "catch.hpp"
+
+// mapnik
+#include <mapnik/map.hpp>
+#include <mapnik/attribute.hpp>
+#include <mapnik/memory_datasource.hpp>
+#include <mapnik/feature_factory.hpp>
+
+// mapnik-vector-tile
+#include "vector_tile_processor.hpp"
+#include "vector_tile_tile.hpp"
+
+
+TEST_CASE("feature processor - can pass variables down to layers")
+{
+    SECTION("variables are optional")
+    {
+        mapnik::Map map(256, 256);
+        mapnik::attributes empty_vars;
+
+        mapnik::vector_tile_impl::processor some_processor(map);
+        CHECK( ( empty_vars == some_processor.get_variables() ) );
+    }
+
+    SECTION("variables can be passed down to the processor")
+    {
+        mapnik::Map map(256, 256);
+        const mapnik::attributes vars { {"zoom_level", 20} };
+
+        mapnik::vector_tile_impl::processor some_processor(map, vars);
+        CHECK( ( vars == some_processor.get_variables() ) );
+    }
+}


### PR DESCRIPTION
This fixes #218 along with a minor change in node-mapnik

What this does:
- it optionally adds a new member `mapnik::attributes vars` to the mvt processor.
- it is passed by `processor::update_tile` to the `tile_layer`, so that it can set the variables of its associated query from there (empty if not passed to the processor constructor).

(thanks @Algunenano for the advice on the constructor)

This is the [patch](https://github.com/CartoDB/node-mapnik/pull/5/commits/5182b7168f3c460cf19b94d98e9cfb9f9a4512f2) that would be required in node-mapnik to indeed pass the variables to the datasources. I haven't created a PR yet because it makes little sense until this one approved.