### PR TITLE
Tileinfo: disable feature id as unset, when it is

### DIFF
--- a/examples/c++/tileinfo.cpp
+++ b/examples/c++/tileinfo.cpp
@@ -209,7 +209,11 @@ int main(int argc, char** argv)
                  for (std::size_t l=0;l<static_cast<std::size_t>(layer.features_size());++l)
                  {
                      vector_tile::Tile_Feature const & feat = layer.features(l);
-                     std::cout << "  feature: " << feat.id() << "\n";
+                     if (feat.has_id()) {
+                         std::cout << "  feature: " << feat.id() << "\n";
+                     } else {
+                         std::cout << "  feature: (no id set)\n";
+                     }
                      std::cout << "    type: ";
                      unsigned feat_type = feat.type();
                      if (feat_type == 0) {


### PR DESCRIPTION
> A feature MAY contain an id field. If a feature has an id field, the value of the id SHOULD be unique among the features of the parent layer.

From https://github.com/mapbox/vector-tile-spec/tree/master/2.1#42-features.

Currently tileinfo outputs `0` for unset feature id properties. Instead I think we should have the output make clear that the feature id is unset, which this PR does.

/cc @mapsam