### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ matrix:
       osx_image: xcode8.3 # upgrades clang from 6 -> 7
 
 before_install:
- - source ./bootstrap.sh
  - ./install_mason.sh
  - |
    if [[ $(uname -s) == 'Linux' ]]; then

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ build/Makefile: mason_packages/.link/bin/mapnik-config ./deps/gyp gyp/build.gyp 
 libvtile: build/Makefile Makefile
 	PATH="`pwd`/mason_packages/.link/bin/:${PATH}" $(MAKE) -C build/ BUILDTYPE=$(BUILDTYPE) V=$(V)
 
-test/geometry-test-data:
+test/geometry-test-data/README.md:
 	git submodule update --init
 
-test: libvtile test/geometry-test-data
+test: libvtile test/geometry-test-data/README.md
 	BUILDTYPE=$(BUILDTYPE) ./test/run.sh
 
 testpack:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test/geometry-test-data:
 	git submodule update --init
 
 test: libvtile test/geometry-test-data
-	BUILDTYPE=$(BUILDTYPE) ./run_tests.sh
+	BUILDTYPE=$(BUILDTYPE) ./test/run.sh
 
 testpack:
 	rm -f ./*tgz

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,13 @@ build/Makefile: mason_packages/.link/bin/mapnik-config ./deps/gyp gyp/build.gyp 
 	deps/gyp/gyp gyp/build.gyp --depth=. -DMAPNIK_PLUGINDIR=\"$(MAPNIK_PLUGINDIR)\" -Goutput_dir=. --generator-output=./build -f make
 
 libvtile: build/Makefile Makefile
-	@$(MAKE) -C build/ BUILDTYPE=$(BUILDTYPE) V=$(V)
+	PATH="`pwd`/mason_packages/.link/bin/:${PATH}" $(MAKE) -C build/ BUILDTYPE=$(BUILDTYPE) V=$(V)
 
 test/geometry-test-data:
 	git submodule update --init
 
 test: libvtile test/geometry-test-data
-	DYLD_LIBRARY_PATH=$(MVT_LIBRARY_PATH) ./build/$(BUILDTYPE)/tests
+	BUILDTYPE=$(BUILDTYPE) ./run_tests.sh
 
 testpack:
 	rm -f ./*tgz

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,10 +3,11 @@
 function setup_runtime_settings() {
     local MASON_LINKED_ABS=$(pwd)/mason_packages/.link
     export PROJ_LIB=${MASON_LINKED_ABS}/share/proj
+    ICU_VERSION=$(ls ${MASON_LINKED_ABS}/share/icu/)
     export ICU_DATA=${MASON_LINKED_ABS}/share/icu/${ICU_VERSION}
     export GDAL_DATA=${MASON_LINKED_ABS}/share/gdal
     if [[ $(uname -s) == 'Darwin' ]]; then
-        export DYLD_LIBRARY_PATH=$(pwd)/mason_packages/.link/lib:${DYLD_LIBRARY_PATH}
+        export DYLD_LIBRARY_PATH=$(pwd)/mason_packages/.link/lib:${DYLD_LIBRARY_PATH:-}
         # OS X > 10.11 blocks DYLD_LIBRARY_PATH so we pass along using a
         # differently named variable
         export MVT_LIBRARY_PATH=${DYLD_LIBRARY_PATH}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,7 +12,7 @@ function setup_runtime_settings() {
         # differently named variable
         export MVT_LIBRARY_PATH=${DYLD_LIBRARY_PATH}
     else
-        export LD_LIBRARY_PATH=$(pwd)/mason_packages/.link/lib:${LD_LIBRARY_PATH}
+        export LD_LIBRARY_PATH=$(pwd)/mason_packages/.link/lib:${LD_LIBRARY_PATH:-}
     fi
     export PATH=$(pwd)/mason_packages/.link/bin:${PATH}
 }

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+source ./bootstrap.sh
+
+BUILDTYPE=${BUILDTYPE:-Release}
+
+./build/${BUILDTYPE}/tests


### PR DESCRIPTION
The build and tests were failing locally for me on OS X. This fixes the core problem:

 - The build and tests need environment variables set dynamically
 - This is very difficult to do in a `Makefile` since you can't `source` bash scripts in makefiles in a portable way on OSX and Linux
 - So, the solution is to:
   - Set specific variables like PATH in  the `Makefile` by pre-pending
   - Call out to a bash script test runner that sources multiple variables

This fixed this build error:

```
PATH="./mason_packages/.link/bin/:/Users/dane/.yarn/bin:/Users/dane/.nvm/versions/node/v4.8.3/bin:/Users/dane/Library/Python/2.7/bin:/Users/dane/.homebrew/opt/coreutils/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands" /Applications/Xcode.app/Contents/Developer/usr/bin/make -C build/ BUILDTYPE=Release V=
  ACTION gyp_build_gyp_make_vector_tile_target_run_protoc Release/obj/gen/vector_tile.pb.cc
/bin/sh: protoc: command not found
make[1]: *** [Release/obj/gen/vector_tile.pb.cc] Error 127
make: *** [libvtile] Error 2
```

And this test error:

```
PATH="`pwd`/mason_packages/.link/bin/:/Users/dane/.yarn/bin:/Users/dane/.nvm/versions/node/v4.8.3/bin:/Users/dane/Library/Python/2.7/bin:/Users/dane/.homebrew/opt/coreutils/libexec/gnubin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands" /Applications/Xcode.app/Contents/Developer/usr/bin/make -C build/ BUILDTYPE=Release V=
make[1]: Nothing to be done for `all'.
DYLD_LIBRARY_PATH= ./build/Release/tests
dyld: Library not loaded: @rpath/libclang_rt.asan_osx_dynamic.dylib
  Referenced from: /usr/local/lib/libmapnik.dylib
  Reason: image not found
make: *** [test] Abort trap: 6
```

/cc @GretaCB @flippmoke 