### PR TITLE
add back ability to build against external mapnik - refs #227

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,4 +64,4 @@ before_script:
 
 script:
  # make sure tileinfo command works
- - ./build/${BUILDTYPE:-Release}/tileinfo examples/data/14_2620_6331.vector.mvt.z
+ - ./build/Debug/tileinfo examples/data/14_2620_6331.vector.mvt.z

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
     - os: linux
       sudo: false
       compiler: ": clang-coverage"
-      env: JOBS=10 CXX="ccache clang++-3.9 -Qunused-arguments" COVERAGE=true BUILDTYPE=Debug
+      env: JOBS=10 CXX="ccache clang++-3.9 -Qunused-arguments" COVERAGE=true
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
@@ -48,11 +48,11 @@ before_install:
  - ./install_mason.sh
  - |
    if [[ $(uname -s) == 'Linux' ]]; then
-     ./mason/mason install llvm-cov 3.9.1
-     ./mason/mason install clang++ 3.9.1
-     export PATH=$(./mason/mason prefix clang++ 3.9.1)/bin:${PATH}
+     ./mason/mason install llvm-cov 4.0.1
+     ./mason/mason install clang++ 4.0.1
+     export PATH=$(./mason/mason prefix clang++ 4.0.1)/bin:${PATH}
      which clang++
-     export PATH=$(./mason/mason prefix llvm-cov 3.9.1)/bin:${PATH}
+     export PATH=$(./mason/mason prefix llvm-cov 4.0.1)/bin:${PATH}
      which llvm-cov
    fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - os: linux
       sudo: false
       compiler: ": gcc5"
-      env: JOBS=10 CXX="ccache g++-5" CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0"
+      env: JOBS=10 CXX="ccache g++-5"
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
@@ -25,7 +25,7 @@ matrix:
     - os: linux
       sudo: false
       compiler: ": clang"
-      env: JOBS=10 CXX="ccache clang++-3.9 -Qunused-arguments"
+      env: JOBS=10 CXX="ccache clang++-4.0 -Qunused-arguments"
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
@@ -33,7 +33,7 @@ matrix:
     - os: linux
       sudo: false
       compiler: ": clang-coverage"
-      env: JOBS=10 CXX="ccache clang++-3.9 -Qunused-arguments" COVERAGE=true
+      env: JOBS=10 CXX="ccache clang++-4.0 -Qunused-arguments" COVERAGE=true
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
@@ -65,7 +65,3 @@ before_script:
 script:
  # make sure tileinfo command works
  - ./build/${BUILDTYPE:-Release}/tileinfo examples/data/14_2620_6331.vector.mvt.z
-
-notifications:
-  slack:
-    secure: eP79cXpZ3zyVarMooLYi75C5XBS65SJkf12h25hLDmoaQD+aX0u3+/hivE3jxi8KI8v1Izpzf06aCGHL1lx/xXGg2uuiM6dtZTou1mJJ4oFsxzOJFfLXhsUO1+qXkJJG1xoaLpbSdX/y+2dfe0xKTm4zAlluj2DvwZO+R9djLGM=

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,6 @@ distclean: clean
 	rm -rf ./deps/gyp
 	rm -rf ./mason_packages
 
-.PHONY: test
+.PHONY: test build/Makefile
 
 

--- a/Makefile
+++ b/Makefile
@@ -17,18 +17,19 @@ pre_build_check:
 
 build/Makefile: ./deps/gyp gyp/build.gyp test/*
 	deps/gyp/gyp gyp/build.gyp --depth=. -DMAPNIK_PLUGINDIR=\"$(shell mapnik-config --input-plugins)\" -Goutput_dir=. --generator-output=./build -f make
+	$(MAKE) -C build/ V=$(V)
 
-release: mason_packages/.link/bin/mapnik-config build/Makefile Makefile
-	CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0" PATH="`pwd`/mason_packages/.link/bin/:${PATH}" $(MAKE) -C build/ BUILDTYPE=Release V=$(V)
+release: mason_packages/.link/bin/mapnik-config Makefile
+	CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0" PATH="`pwd`/mason_packages/.link/bin/:${PATH}" $(MAKE) release_base
 
-debug: mason_packages/.link/bin/mapnik-config build/Makefile Makefile
-	CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0" PATH="`pwd`/mason_packages/.link/bin/:${PATH}" $(MAKE) -C build/ BUILDTYPE=Debug V=$(V)
+debug: mason_packages/.link/bin/mapnik-config Makefile
+	CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0" PATH="`pwd`/mason_packages/.link/bin/:${PATH}" $(MAKE) debug_base
 
-release_base: pre_build_check mason_packages/.link/bin build/Makefile Makefile
-	$(MAKE) -C build/ BUILDTYPE=Release V=$(V)
+release_base: pre_build_check mason_packages/.link/bin Makefile
+	BUILDTYPE=Release $(MAKE) build/Makefile
 
-debug_base: pre_build_check mason_packages/.link/bin build/Makefile Makefile
-	$(MAKE) -C build/ BUILDTYPE=Debug V=$(V)
+debug_base: pre_build_check mason_packages/.link/bin Makefile
+	BUILDTYPE=Debug $(MAKE) build/Makefile
 
 test/geometry-test-data/README.md:
 	git submodule update --init
@@ -49,6 +50,8 @@ clean:
 	rm -rf ./build
 
 distclean: clean
+	rm -rf ./mason
+	rm -rf ./deps/gyp
 	rm -rf ./mason_packages
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ GYP_REVISION=3464008
 default: release
 
 mason_packages/.link/bin:
-	./install_mason.sh
+	SKIP_MAPNIK_INSTALL=YES ./install_mason.sh
 
 mason_packages/.link/bin/mapnik-config:
-	SKIP_MAPNIK_INSTALL=YES ./install_mason.sh
+	./install_mason.sh
 
 pre_build_check:
 	@echo "Looking for mapnik-config on your PATH..."

--- a/README.md
+++ b/README.md
@@ -11,7 +11,29 @@ Provides C++ headers that support rendering geodata into vector tiles and render
 
 ## Depends
 
-Mapnik Vector Tile does not currently support Mapnik 3.1.x.
+## Implementation details
+
+Vector tiles in this code represent a direct serialization of Mapnik layers optimized for space efficient storage and fast deserialization. For those familiar with the Mapnik API vector tiles here can be considered a named array of `mapnik::featureset_ptr` whose geometries have been pre-tiled.
+
+For more details see [vector-tile-spec](https://github.com/mapbox/vector-tile-spec).
+
+## Building from source
+
+If you do not need to build against an external mapnik, just type:
+
+    make
+
+This will download all deps (including Mapnik) and compile against them.
+
+To build and test in debug mode do:
+
+    make debug test-debug
+
+If you have Mapnik, libprotobuf, and all the Mapnik deps already installed on your system then you can build against them with:
+
+    make release_base
+
+If building against an external Mapnik please know that Mapnik Vector Tile does not currently support Mapnik 3.1.x.
 
  - mapnik-vector-tile >=1.4.x depends on Mapnik >=v3.0.14
  - mapnik-vector-tile >=1.0.x depends on Mapnik >=v3.0.11
@@ -20,33 +42,6 @@ Mapnik Vector Tile does not currently support Mapnik 3.1.x.
  - You will need `libmapnik` and `mapnik-config` available
  - Protobuf: `libprotobuf` and `protoc`
 
-## Implementation details
-
-Vector tiles in this code represent a direct serialization of Mapnik layers optimized for space efficient storage and fast deserialization. For those familiar with the Mapnik API vector tiles here can be considered a named array of `mapnik::featureset_ptr` whose geometries have been pre-tiled.
-
-For more details see [vector-tile-spec](https://github.com/mapbox/vector-tile-spec).
-
-### Ubuntu Dependencies Installation
-
-    sudo apt-get install -y libprotobuf7 libprotobuf-dev protobuf-compiler
-    sudo apt-add-repository --yes ppa:mapnik/nightly-2.3
-    sudo apt-get update -y
-    sudo apt-get -y install libmapnik=2.3.0* mapnik-utils=2.3.0* libmapnik-dev=2.3.0* mapnik-input-plugin*=2.3.0*
-
-### OS X Dependencies Installation
-
-    brew install protobuf
-    brew install mapnik
-
-## Building
-
-Just type:
-
-    make
-
-This builds the protobuf C++ wrappers: `vector_tile.pb.cc` and `vector_tile.pb.h`
-
-Then include `vector_tile.pb.cc` in your code. The rest is header only.
 
 ## Tests
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,20 +1,27 @@
 #!/usr/bin/env bash
 
+# if built against mason package fix dynamic data locations
 function setup_runtime_settings() {
-    local MASON_LINKED_ABS=$(pwd)/mason_packages/.link
-    export PROJ_LIB=${MASON_LINKED_ABS}/share/proj
-    ICU_VERSION=$(ls ${MASON_LINKED_ABS}/share/icu/)
-    export ICU_DATA=${MASON_LINKED_ABS}/share/icu/${ICU_VERSION}
-    export GDAL_DATA=${MASON_LINKED_ABS}/share/gdal
-    if [[ $(uname -s) == 'Darwin' ]]; then
-        export DYLD_LIBRARY_PATH=$(pwd)/mason_packages/.link/lib:${DYLD_LIBRARY_PATH:-}
-        # OS X > 10.11 blocks DYLD_LIBRARY_PATH so we pass along using a
-        # differently named variable
-        export MVT_LIBRARY_PATH=${DYLD_LIBRARY_PATH}
-    else
-        export LD_LIBRARY_PATH=$(pwd)/mason_packages/.link/lib:${LD_LIBRARY_PATH:-}
+    if [[ -f $(pwd)/mason_packages/.link/bin/mapnik-config ]]; then
+        # TODO: use --proj-lib, --gdal-data, etc after https://github.com/mapnik/mapnik/pull/3759 is fixed
+        #export PROJ_LIB=$(mapnik-config --proj-lib)
+        #export GDAL_DATA=$(mapnik-config --gdal-data)
+        #export ICU_DATA=$(mapnik-config --icu-data)
+        local MASON_LINKED_ABS=$(pwd)/mason_packages/.link
+        export PROJ_LIB=${MASON_LINKED_ABS}/share/proj
+        ICU_VERSION=$(ls ${MASON_LINKED_ABS}/share/icu/)
+        export ICU_DATA=${MASON_LINKED_ABS}/share/icu/${ICU_VERSION}
+        export GDAL_DATA=${MASON_LINKED_ABS}/share/gdal
+        if [[ $(uname -s) == 'Darwin' ]]; then
+            export DYLD_LIBRARY_PATH=$(pwd)/mason_packages/.link/lib:${DYLD_LIBRARY_PATH:-}
+            # OS X > 10.11 blocks DYLD_LIBRARY_PATH so we pass along using a
+            # differently named variable
+            export MVT_LIBRARY_PATH=${DYLD_LIBRARY_PATH}
+        else
+            export LD_LIBRARY_PATH=$(pwd)/mason_packages/.link/lib:${LD_LIBRARY_PATH:-}
+        fi
+        export PATH=$(pwd)/mason_packages/.link/bin:${PATH}
     fi
-    export PATH=$(pwd)/mason_packages/.link/bin:${PATH}
 }
 
 function main() {

--- a/gyp/build.gyp
+++ b/gyp/build.gyp
@@ -38,17 +38,18 @@
       ],
       'include_dirs': [
         '<(SHARED_INTERMEDIATE_DIR)/',
+        '../mason_packages/.link/include/'
       ],
       'cflags_cc' : [
           '-D_THREAD_SAFE',
-          '<!@(../mason_packages/.link/bin/mapnik-config --cflags)', # assume protobuf headers are here
+          '<!@(mapnik-config --cflags)', # assume protobuf headers are here
           '-Wno-sign-compare',
           '-Wno-sign-conversion'
       ],
       'xcode_settings': {
         'OTHER_CPLUSPLUSFLAGS':[
            '-D_THREAD_SAFE',
-           '<!@(../mason_packages/.link/bin/mapnik-config --cflags)', # assume protobuf headers are here
+           '<!@(mapnik-config --cflags)', # assume protobuf headers are here
            '-Wno-sign-compare',
            '-Wno-sign-conversion'
         ],
@@ -56,6 +57,7 @@
       'direct_dependent_settings': {
         'include_dirs': [
           '<(SHARED_INTERMEDIATE_DIR)/',
+          '../mason_packages/.link/include/'
         ],
         'libraries':[
           '-lprotobuf-lite'
@@ -82,34 +84,35 @@
         "<@(common_defines)"
       ],
       'cflags_cc' : [
-          '<!@(../mason_packages/.link/bin/mapnik-config --cflags)'
+          '<!@(mapnik-config --cflags)'
       ],
       'xcode_settings': {
         'OTHER_CPLUSPLUSFLAGS':[
-           '<!@(../mason_packages/.link/bin/mapnik-config --cflags)'
+           '<!@(mapnik-config --cflags)'
         ],
       },
       'direct_dependent_settings': {
         'include_dirs': [
           '<(SHARED_INTERMEDIATE_DIR)/',
+          '../mason_packages/.link/include/'
         ],
         'defines' : [
           "<@(common_defines)"
         ],
         'cflags_cc' : [
-            '<!@(../mason_packages/.link/bin/mapnik-config --cflags)'
+            '<!@(mapnik-config --cflags)'
         ],
         'xcode_settings': {
           'OTHER_CPLUSPLUSFLAGS':[
-             '<!@(../mason_packages/.link/bin/mapnik-config --cflags)'
+             '<!@(mapnik-config --cflags)'
           ],
         },
         'libraries':[
-          '<!@(../mason_packages/.link/bin/mapnik-config --libs)',
-          '<!@(../mason_packages/.link/bin/mapnik-config --ldflags)',
+          '<!@(mapnik-config --libs)',
+          '<!@(mapnik-config --ldflags)',
           '-lmapnik-wkt',
           '-lmapnik-json',
-          '<!@(../mason_packages/.link/bin/mapnik-config --dep-libs)',
+          '<!@(mapnik-config --dep-libs)',
           '-lprotobuf-lite',
           '-lz'
         ],
@@ -203,18 +206,18 @@
         "../src"
       ],
       'libraries':[
-        '-L<!@(../mason_packages/.link/bin/mapnik-config --prefix)/lib',
-        '<!@(../mason_packages/.link/bin/mapnik-config --ldflags)',
+        '-L<!@(mapnik-config --prefix)/lib',
+        '<!@(mapnik-config --ldflags)',
         '-lz'
       ],
       'cflags_cc' : [
           '-D_THREAD_SAFE',
-          '<!@(../mason_packages/.link/bin/mapnik-config --cflags)' # assume protobuf headers are here
+          '<!@(mapnik-config --cflags)' # assume protobuf headers are here
       ],
       'xcode_settings': {
         'OTHER_CPLUSPLUSFLAGS':[
            '-D_THREAD_SAFE',
-           '<!@(../mason_packages/.link/bin/mapnik-config --cflags)' # assume protobuf headers are here
+           '<!@(mapnik-config --cflags)' # assume protobuf headers are here
         ],
       }
     }    

--- a/install_mason.sh
+++ b/install_mason.sh
@@ -9,17 +9,18 @@ function install() {
 }
 
 ICU_VERSION="57.1"
+MASON_VERSION="v1.14.2"
 
 if [ ! -f ./mason/mason.sh ]; then
     mkdir -p ./mason
-    curl -sSfL https://github.com/mapbox/mason/archive/9eac60614fda7cfeb8a9e81d18e8cca5c1ae8fbc.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=./mason
+    curl -sSfL https://github.com/mapbox/mason/archive/${MASON_VERSION}.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=./mason
 fi
 
 # core deps
-install protozero 1.5.1
-install geometry 0.9.1
-install wagyu 0.4.2
-install protobuf 2.6.1
+install protozero 1.5.2
+install geometry 0.9.2
+install wagyu 0.4.3
+install protobuf 3.3.0
 
 # mapnik
 if [[ ! ${SKIP_MAPNIK_INSTALL:-true} ]] && [[ ! -f ./mason_packages/.link/bin/mapnik-config ]]; then

--- a/install_mason.sh
+++ b/install_mason.sh
@@ -23,7 +23,7 @@ install wagyu 0.4.3
 install protobuf 3.3.0
 
 # mapnik
-if [[ ! ${SKIP_MAPNIK_INSTALL:-true} ]] && [[ ! -f ./mason_packages/.link/bin/mapnik-config ]]; then
+if [[ ${SKIP_MAPNIK_INSTALL:-} != 'YES' ]] && [[ ! -f ./mason_packages/.link/bin/mapnik-config ]]; then
 
     # mapnik deps
     install jpeg_turbo 1.5.1

--- a/install_mason.sh
+++ b/install_mason.sh
@@ -9,7 +9,7 @@ function install() {
 }
 
 ICU_VERSION="57.1"
-MASON_VERSION="v1.14.2"
+MASON_VERSION="v0.14.2"
 
 if [ ! -f ./mason/mason.sh ]; then
     mkdir -p ./mason

--- a/install_mason.sh
+++ b/install_mason.sh
@@ -22,7 +22,7 @@ install wagyu 0.4.2
 install protobuf 2.6.1
 
 # mapnik
-if [[ ! ${SKIP_MAPNIK_INSTALL} ]] && [[ ! -f ./mason_packages/.link/bin/mapnik-config ]]; then
+if [[ ! ${SKIP_MAPNIK_INSTALL:-true} ]] && [[ ! -f ./mason_packages/.link/bin/mapnik-config ]]; then
 
     # mapnik deps
     install jpeg_turbo 1.5.1

--- a/install_mason.sh
+++ b/install_mason.sh
@@ -15,7 +15,14 @@ if [ ! -f ./mason/mason.sh ]; then
     curl -sSfL https://github.com/mapbox/mason/archive/9eac60614fda7cfeb8a9e81d18e8cca5c1ae8fbc.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=./mason
 fi
 
-if [ ! -f ./mason_packages/.link/bin/mapnik-config ]; then
+# core deps
+install protozero 1.5.1
+install geometry 0.9.1
+install wagyu 0.4.2
+install protobuf 2.6.1
+
+# mapnik
+if [[ ! ${SKIP_MAPNIK_INSTALL} ]] && [[ ! -f ./mason_packages/.link/bin/mapnik-config ]]; then
 
     # mapnik deps
     install jpeg_turbo 1.5.1
@@ -37,9 +44,4 @@ if [ ! -f ./mason_packages/.link/bin/mapnik-config ]; then
     # mapnik
     install mapnik 3.0.14
 
-    # other deps
-    install protozero 1.5.1
-    install geometry 0.9.1
-    install wagyu 0.4.2
-    install protobuf 2.6.1
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,6 +5,8 @@ if [[ ${COVERAGE:-false} == true ]]; then
     # test only debug version
     export LDFLAGS="--coverage"
     export CXXFLAGS="--coverage"
+    make debug -j${JOBS:-1} V=1
+    make test-debug
 else
     # test both release and debug
     make release -j${JOBS:-1} V=1

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,10 +2,15 @@ set -e -u
 set -o pipefail
 
 if [[ ${COVERAGE:-false} == true ]]; then
+    # test only debug version
     export LDFLAGS="--coverage"
     export CXXFLAGS="--coverage"
+else
+    # test both release and debug
+    make release -j${JOBS:-1} V=1
+    make test
+    make debug -j${JOBS:-1} V=1
+    make test-debug
 fi
-
-make -j${JOBS:-1} test BUILDTYPE=${BUILDTYPE:-Release} V=1
 
 set +e +u


### PR DESCRIPTION
#227 ported the build system to use mason. With this PR, mason is still the default if you run `make`. But also you can now build against an external mapnik with `make release_base`