### PR TITLE
Fix improper clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.1
+
+- Fix bug where on linestring and point data the clipping box passed to boost geometry was malformed.
+
 ## 2.2.0
 
 - Changed the underlying storage of the tile buffer to be a unique ptr controlled string so that it could be passed off if necessary outside the tile class.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
     "name": "mapnik-vector-tile",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "description": "Mapnik Vector Tile API",
     "main": "include_dirs.js",
-    "repository"   :  {
-      "type" : "git",
-      "url"  : "git://github.com/mapbox/mapnik-vector-tile.git"
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/mapbox/mapnik-vector-tile.git"
     }
 }

--- a/src/vector_tile_geometry_clipper.hpp
+++ b/src/vector_tile_geometry_clipper.hpp
@@ -65,7 +65,8 @@ inline mapbox::geometry::wagyu::fill_type get_wagyu_fill_type(polygon_fill_type 
 template <typename T>
 mapbox::geometry::linear_ring<T> box_to_ring(mapbox::geometry::box<T> const& box)
 {
-    mapbox::geometry::linear_ring<T> ring(5);
+    mapbox::geometry::linear_ring<T> ring;
+    ring.reserve(5);
     ring.emplace_back(box.min.x, box.min.y);
     ring.emplace_back(box.max.x, box.min.y);
     ring.emplace_back(box.max.x, box.max.y);


### PR DESCRIPTION
Fix mistake where initializing 5 values to default values was used rather then reserve in the clipping bound box function. This was causing a strange polygon with 5 extra points at 0,0 to be passed directly into the clipping function. The first I have noticed that caused this was https://github.com/mapnik/node-mapnik/issues/892. We need to patch this and push upstream quickly. 