### PR TITLE
Layer: Always calculate precision as extent per width|height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.0
+
+- Set up layer resolution as layer extent (4096 by default) per width or height. Previously, if the layer had a datasource of type Vector the resolution would be set as 256 per layer width or height which caused some incorrect interactions with some Mapnik plugins that use this value to modify geometries. From now on, these operations will be done depending on the layer extent and not the default 256.
+This change will only affect those that are using the Postgis plugin with simplification enabled (`simplify_distance : true`) or the Pgraster plugin using overviews (`use_overviews : true`) or raster prescaling (`prescale_rasters: true`). None of the options above are the default ones for those plugins.
+
 ## 2.2.1
 
 - Fix bug where on linestring and point data the clipping box passed to boost geometry was malformed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mapnik-vector-tile",
-    "version": "2.2.1",
+    "version": "3.0.0",
     "description": "Mapnik Vector Tile API",
     "main": "include_dirs.js",
     "repository": {

--- a/src/vector_tile_layer.hpp
+++ b/src/vector_tile_layer.hpp
@@ -328,16 +328,8 @@ public:
         }
         double qw = unbuffered_query_extent.width() > 0 ? unbuffered_query_extent.width() : 1.0;
         double qh = unbuffered_query_extent.height() > 0 ? unbuffered_query_extent.height() : 1.0;
-        if (!ds_ || ds_->type() == datasource::Vector)
-        {
-            qw = VT_LEGACY_IMAGE_SIZE / qw;
-            qh = VT_LEGACY_IMAGE_SIZE / qh;
-        }
-        else
-        {
-            qw = static_cast<double>(layer_extent_) / qw;
-            qh = static_cast<double>(layer_extent_) / qh;
-        }
+        qw = static_cast<double>(layer_extent_) / qw;
+        qh = static_cast<double>(layer_extent_) / qh;
 
         mapnik::query::resolution_type res(qw, qh);
         mapnik::query q(query_extent, res, scale_denom, unbuffered_query_extent);


### PR DESCRIPTION
Closes https://github.com/mapbox/mapnik-vector-tile/issues/289

- Changes how the resolution of the mapnik::query is calculated. Given the formula: `X / width` and `X / height`:
- `!ds`: X used to be 256. Now it's 4096.
- `ds.type == datasource::Vector` && `vector_layer_extent` declared: X used to be 256. Now it's equal to `vector_layer_extent`.
- `ds.type == datasource::Vector` && `vector_layer_extent` NOT declared: X used to be 256. Now it's 4096.
` ds.type != datasource::Vector` && `vector_layer_extent` declared. Used to be 256. Stays the same.
` ds.type != datasource::Vector` && `vector_layer_extent` NOT declared. Used to be 4096. Stays the same.